### PR TITLE
Fixed issues with host lookup from hosts file

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/BukkitJoinListener.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/BukkitJoinListener.java
@@ -51,7 +51,7 @@ public class BukkitJoinListener implements Listener {
             public void run() {
                 if (player.isOnline()) {
                     //remove the bungeecord identifier
-                    String id = '/' + player.getAddress().getHostString() + ':' + player.getAddress().getPort();
+                    String id = '/' + player.getAddress().getAddress().getHostAddress()  + ':' + player.getAddress().getPort();
                     PlayerSession session = plugin.getSessions().get(id);
 
                     //blacklist this target player for BungeeCord Id brute force attacks


### PR DESCRIPTION
I have values set in my hosts file and the original way of getting the address returnned the hostname it was linked to.