### PR TITLE
Consistency language update

### DIFF
--- a/core/src/main/resources/messages.yml
+++ b/core/src/main/resources/messages.yml
@@ -28,7 +28,7 @@ add-premium: '&2Added to the list of premium players'
 already-exists: '&4You are already on the premium list'
 
 # Player is already set be a paid account
-already-exists-other: '&4You are already on the premium list'
+already-exists-other: '&4Player is already on the premium list'
 
 # Player was changed to be cracked
 remove-premium: '&2Removed from the list of premium players'
@@ -37,7 +37,7 @@ remove-premium: '&2Removed from the list of premium players'
 not-premium: '&4You are not in the premium list'
 
 # Player is already set to be cracked
-not-premium-other: '&4You are not in the premium list'
+not-premium-other: '&4Player is not in the premium list'
 
 # Admin wanted to change the premium of a user that isn't known to the plugin
 player-unknown: '&4Player not in the database'
@@ -84,8 +84,8 @@ invalid-requst: '&4Invalid request'
 not-started: '&cServer is not fully started yet. Please retry'
 
 # Warning message if a user invoked /premium command
-premium-warning: '&6WARNING: This command should only be invoked if you are the owner of this paid minecraft account
-Type /premium again to confirm'
+premium-warning: '&c&lWARNING: &6This command should &lonly&6 be invoked if you are the owner of this paid minecraft account
+Type &a/premium&r again to confirm'
 
 # ========= Bungee/Waterfall only ================================
 


### PR DESCRIPTION
Messages that aren't targeted to the player invoking the command shouldn't start with "You are", that could be confusing.

Changed Warning message to be more eye-catching to the player. Assuming also that next line doesn't take the color code from previous line (otherwise change "&r" with "&6").