### PR TITLE
Add a workaround fix for CatServer / Magma servers

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ProtocolLibListener.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ProtocolLibListener.java
@@ -53,8 +53,7 @@ public class ProtocolLibListener extends PacketAdapter {
         }
 
         Player sender = packetEvent.getPlayer();
-        PacketType packetType = packetEvent.getPacketType();
-        if (packetType == START) {
+        if (isPacketLoginInStart(packetEvent.getPacket())) {
             if (!rateLimiter.tryAcquire()) {
                 plugin.getLog().warn("Rate Limit hit - Ignoring player {}", sender);
                 return;
@@ -64,6 +63,11 @@ public class ProtocolLibListener extends PacketAdapter {
         } else {
             onEncryptionBegin(packetEvent, sender);
         }
+    }
+
+    private boolean isPacketLoginInStart(PacketContainer packet) {
+        // Workaround for ProtocolLib issues on CatServer / Magma servers.
+        return packet.getGameProfiles().size() > 0;
     }
 
     private void onEncryptionBegin(PacketEvent packetEvent, Player sender) {


### PR DESCRIPTION
[//]: # (Lines in this format are considered as comments and will not be displayed.)
[//]: # (If your work is in progress, please consider making a draft pull request.)

### Summary of your change
[//]: # (Example: motiviation, enhancement)
This PR contains a workaround fix for ProtocolLib wrongly identifying PacketType under bukkit-forge hybrid servers like CatServer and Magma. The issue caused FastLogin throws errors when client sends PacketLoginInStart packet, but incorrectly handled as PacketLoginEncryptionBegin.

### Related issue
[//]: # (Reference it using '#NUMBER'. Ex: Fixes/Related #...)
None?
