### PR TITLE
Fix name change detection, allow FastLogin to respect AuthMe registration limits

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -41,6 +41,10 @@
                             <pattern>com.google.gson</pattern>
                             <shadedPattern>fastlogin.gson</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>io.papermc.lib</pattern>
+                            <shadedPattern>fastlogin.paperlib</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>
@@ -56,14 +60,10 @@
     </build>
 
     <repositories>
-        <!-- Bukkit-Server-API -->
+        <!-- PaperSpigot API and PaperLib -->
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-            <!-- Disable snapshot release policy to speed up, when finding a artifact -->
-            <releases>
-                <enabled>false</enabled>
-            </releases>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
         </repository>
 
         <!-- ProtocolLib -->
@@ -108,12 +108,20 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!--Server API-->
+        <!-- PaperSpigot API for correcting usercache usage -->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper-api</artifactId>
             <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- PaperLib for checking if server uses PaperSpigot -->
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.6</version>
+            <scope>compile</scope>
         </dependency>
 
         <!--Library for listening and sending Minecraft packets-->

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/hook/AuthMeHook.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/hook/AuthMeHook.java
@@ -3,14 +3,17 @@ package com.github.games647.fastlogin.bukkit.hook;
 import com.github.games647.fastlogin.bukkit.BukkitLoginSession;
 import com.github.games647.fastlogin.bukkit.FastLoginBukkit;
 import com.github.games647.fastlogin.core.hooks.AuthPlugin;
-
 import fr.xephi.authme.api.v3.AuthMeApi;
 import fr.xephi.authme.events.RestoreSessionEvent;
-
+import fr.xephi.authme.process.Management;
+import fr.xephi.authme.process.register.executors.ApiPasswordRegisterParams;
+import fr.xephi.authme.process.register.executors.RegistrationMethod;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+
+import java.lang.reflect.Field;
 
 /**
  * GitHub: https://github.com/Xephi/AuthMeReloaded/
@@ -25,8 +28,22 @@ public class AuthMeHook implements AuthPlugin<Player>, Listener {
 
     private final FastLoginBukkit plugin;
 
+    private final AuthMeApi authmeAPI;
+    private Management authmeManagement;
+
     public AuthMeHook(FastLoginBukkit plugin) {
         this.plugin = plugin;
+        this.authmeAPI = AuthMeApi.getInstance();
+
+        if (plugin.getConfig().getBoolean("respectIpLimit", false)) {
+            try {
+                Field managementField = this.authmeAPI.getClass().getDeclaredField("management");
+                managementField.setAccessible(true);
+                this.authmeManagement = (Management) managementField.get(this.authmeAPI);
+            } catch (NoSuchFieldException | IllegalAccessException exception) {
+                this.authmeManagement = null;
+            }
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -41,25 +58,32 @@ public class AuthMeHook implements AuthPlugin<Player>, Listener {
 
     @Override
     public boolean forceLogin(Player player) {
-        if (AuthMeApi.getInstance().isAuthenticated(player)) {
+        if (authmeAPI.isAuthenticated(player)) {
             plugin.getLog().warn(ALREADY_AUTHENTICATED, player);
             return false;
         }
 
         //skips registration and login
-        AuthMeApi.getInstance().forceLogin(player);
+        authmeAPI.forceLogin(player);
         return true;
     }
 
     @Override
     public boolean isRegistered(String playerName) {
-        return AuthMeApi.getInstance().isRegistered(playerName);
+        return authmeAPI.isRegistered(playerName);
     }
 
     @Override
+    //this automatically login the player too
     public boolean forceRegister(Player player, String password) {
-        //this automatically login the player too
-        AuthMeApi.getInstance().forceRegister(player, password);
-        return true;
+        //if we have the management - we can trigger register with IP limit checks
+        if (authmeManagement != null) {
+            authmeManagement.performRegister(RegistrationMethod.PASSWORD_REGISTRATION,
+                    ApiPasswordRegisterParams.of(player, password, true));
+        } else {
+            authmeAPI.forceRegister(player, password);
+        }
+
+        return authmeAPI.isRegistered(player.getName());
     }
 }

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/hook/AuthMeHook.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/hook/AuthMeHook.java
@@ -84,6 +84,6 @@ public class AuthMeHook implements AuthPlugin<Player>, Listener {
             authmeAPI.forceRegister(player, password);
         }
 
-        return authmeAPI.isRegistered(player.getName());
+        return true;
     }
 }

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/PaperPreLoginListener.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/PaperPreLoginListener.java
@@ -1,0 +1,41 @@
+package com.github.games647.fastlogin.bukkit.listener;
+
+import com.destroystokyo.paper.profile.ProfileProperty;
+import com.github.games647.craftapi.model.skin.Textures;
+import com.github.games647.fastlogin.bukkit.BukkitLoginSession;
+import com.github.games647.fastlogin.bukkit.FastLoginBukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent.Result;
+
+public class PaperPreLoginListener implements Listener {
+
+    private final FastLoginBukkit plugin;
+
+    public PaperPreLoginListener(final FastLoginBukkit plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    //if paper is used - player skin must be set at pre login, otherwise usercache is used
+    //using usercache makes premium name change basically impossible
+    public void onAsyncPlayerPreLogin(AsyncPlayerPreLoginEvent event) {
+        if (event.getLoginResult() != Result.ALLOWED) {
+            return;
+        }
+
+        // event gives us only IP, not the port, so we need to loop through all the sessions
+        for (BukkitLoginSession session : plugin.getLoginSessions().values()) {
+            if (!event.getName().equals(session.getUsername())) {
+                continue;
+            }
+
+            session.getSkin().ifPresent(skin -> event.getPlayerProfile().setProperty(new ProfileProperty(Textures.KEY,
+                    skin.getValue(), skin.getSignature())));
+            break;
+        }
+    }
+
+}

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/SkinApplyListener.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/SkinApplyListener.java
@@ -9,15 +9,14 @@ import com.comphenix.protocol.wrappers.WrappedSignedProperty;
 import com.github.games647.craftapi.model.skin.Textures;
 import com.github.games647.fastlogin.bukkit.BukkitLoginSession;
 import com.github.games647.fastlogin.bukkit.FastLoginBukkit;
-
-import java.lang.reflect.InvocationTargetException;
-
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerLoginEvent.Result;
+
+import java.lang.reflect.InvocationTargetException;
 
 public class SkinApplyListener implements Listener {
 
@@ -39,14 +38,12 @@ public class SkinApplyListener implements Listener {
 
         Player player = loginEvent.getPlayer();
 
-        if (plugin.getConfig().getBoolean("forwardSkin")) {
-            //go through every session, because player.getAddress is null
-            //loginEvent.getAddress is just a InetAddress not InetSocketAddress, so not unique enough
-            for (BukkitLoginSession session : plugin.getLoginSessions().values()) {
-                if (session.getUsername().equals(player.getName())) {
-                    session.getSkin().ifPresent(skin -> applySkin(player, skin.getValue(), skin.getSignature()));
-                    break;
-                }
+        //go through every session, because player.getAddress is null
+        //loginEvent.getAddress is just a InetAddress not InetSocketAddress, so not unique enough
+        for (BukkitLoginSession session : plugin.getLoginSessions().values()) {
+            if (session.getUsername().equals(player.getName())) {
+                session.getSkin().ifPresent(skin -> applySkin(player, skin.getValue(), skin.getSignature()));
+                break;
             }
         }
     }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -36,6 +36,15 @@ anti-bot:
 # For more information: https://github.com/games647/FastLogin#why-do-players-have-to-invoke-a-command
 autoRegister: false
 
+# Should FastLogin respect per IP limit of registrations (e.g. in AuthMe)
+# Because most auth plugins do their stuff async - FastLogin will still think the player was registered
+# To work best - you also need to enable auto-register-unknown
+#
+# If set to true - FastLogin will always attempt to register the player, even if the limit is exceeded
+# It is up to the auth plugin to handle the excessive registration
+# https://github.com/games647/FastLogin/issues/458
+respectIpLimit: false
+
 # This is extra configuration option to the feature above. If we request a premium authentication from a player who
 # isn't actual premium but used a premium username, the player will disconnect with the reason "invalid session" or
 # "bad login".
@@ -129,6 +138,7 @@ nameChangeCheck: false
 #
 # If you use PaperSpigot - FastLogin will always try to set the skin, even if forwardSkin is set to false
 # It is needed to allow premium name change to work correctly
+# https://github.com/games647/FastLogin/issues/457
 #
 # If you want to use skins for your cracked player, you need an additional plugin like
 # ChangeSkin, SkinRestorer, ...

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -127,6 +127,9 @@ nameChangeCheck: false
 # the skin data is included in the Auth-Verification-Response sent by Mojang. If you want to use for other
 # players like cracked player, you have to use other plugins.
 #
+# If you use PaperSpigot - FastLogin will always try to set the skin, even if forwardSkin is set to false
+# It is needed to allow premium name change to work correctly
+#
 # If you want to use skins for your cracked player, you need an additional plugin like
 # ChangeSkin, SkinRestorer, ...
 forwardSkin: true

--- a/core/src/main/resources/messages.yml
+++ b/core/src/main/resources/messages.yml
@@ -53,10 +53,10 @@ player-unknown: '&4Player not in the database'
 # The user skipped the authentication, because it was a premium player
 auto-login: '&2Auto logged in'
 
-# The user was auto registered on the first join. The user account will be registered to protect it from cracked players
+# FastLogin attempted to auto register user. The user account is registered to protect it from cracked players
+# If FastLogin is respecting auth plugin IP limit - the registration may have failed, however the message is still displayed
 # The password can be used if the mojang servers are down and you still want your premium users to login (PLANNED)
-auto-register: '&2Auto registered with password: %password
-You may want change it?'
+auto-register: '&2Tried auto registering with password: &7%password&2. You may want change it?'
 
 # GameProfile is not able to toggle the premium state of other players
 no-permission: '&4Not enough permissions'


### PR DESCRIPTION
### Summary of your change
First change fixes name change detection on PaperSpigot. Because the gameprofile didn't have the skin set and the server is set to offline-mode - Paper was using a cached profile from usercache.json, which had the old username. That way the name change was spotted, but basically ignored by Paper.

Second change allows to respect the per IP registration limit of AuthMe. Due to the limitations of its API - some reflections have to be used. When registering using the API - a different type of registration is triggered. The API one doesn't check for IP limits. The reflection allows FastLogin to trigger a registration like it would be done using the `/register` command - that way the limits will be checked.

Also because AuthMe makes the registration async - there's no good way to detect if the registration was successful, FastLogin will always display a message about auto-register and then AuthMe will send a message about IP limit. I've changed the default auto-register message to at least a bit account for possible registration fail.

### Related issue
Fixes #423, #437, #457, #458
