### PR TITLE
Fix Floodgate 2.0 on BungeeCord

### DIFF
--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -124,10 +124,20 @@
         </dependency>
 
         <!-- Bedrock player bridge -->
+        <!-- Should be removed one Floodgate 2.0 gets a stable release -->
         <dependency>
             <groupId>org.geysermc</groupId>
             <artifactId>floodgate-bungee</artifactId>
             <version>1.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Bedrock player bridge -->
+        <!-- Version 2.0 -->
+        <dependency>
+            <groupId>org.geysermc.floodgate</groupId>
+            <artifactId>bungee</artifactId>
+            <version>2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
@@ -87,8 +87,15 @@ public class FastLoginBungee extends Plugin implements PlatformPlugin<CommandSen
 
         //events
         PluginManager pluginManager = getProxy().getPluginManager();
-        boolean floodgateAvail = pluginManager.getPlugin("floodgate") != null;
-        ConnectListener connectListener = new ConnectListener(this, core.getRateLimiter(), floodgateAvail);
+
+        //check Floodgate version
+        String floodgateVersion = "0";
+        Plugin floodgatePlugin = pluginManager.getPlugin("floodgate");
+        if (floodgatePlugin != null) {
+            floodgatePlugin.getDescription().getVersion();
+        }
+
+        ConnectListener connectListener = new ConnectListener(this, core.getRateLimiter(), floodgateVersion);
 
         pluginManager.registerListener(this, connectListener);
         pluginManager.registerListener(this, new PluginMessageListener(this));

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
@@ -98,12 +98,12 @@ public class ConnectListener implements Listener {
     private final FastLoginBungee plugin;
     private final RateLimiter rateLimiter;
     private final Property[] emptyProperties = {};
-    private final boolean floodGateAvailable;
+    private final String floodgateVersion;
 
-    public ConnectListener(FastLoginBungee plugin, RateLimiter rateLimiter, boolean floodgateAvailable) {
+    public ConnectListener(FastLoginBungee plugin, RateLimiter rateLimiter, String floodgateVersion) {
         this.plugin = plugin;
         this.rateLimiter = rateLimiter;
-        this.floodGateAvailable = floodgateAvailable;
+        this.floodgateVersion = floodgateVersion;
     }
 
     @EventHandler
@@ -211,6 +211,12 @@ public class ConnectListener implements Listener {
         // Floodgate will set a correct UUID at the beginning of the PreLoginEvent
         // and will cancel the online mode login for those players
         // Therefore we just ignore those
-        return floodGateAvailable && FloodgateAPI.isBedrockPlayer(correctedUUID);
+        if (floodgateVersion.startsWith("1")) {
+            return FloodgateAPI.isBedrockPlayer(correctedUUID);
+        } else if (floodgateVersion.startsWith("2")) {
+            return FloodgateAPI.isBedrockPlayer(correctedUUID);
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
### Summary of your change
In floodgate 2.0 the API instance was changed from `FloodgateAPI` to `FloodgateApi` which caused the API calls not to work.
A version checking has been added to determine if floodgate 1 or 2 is used and use the proper API.

This is just a hotfix and does not implement the features from https://github.com/games647/FastLogin/pull/494. I might do that in a future PR, but I think that existing features should be fixed first.

### Related issue
Fixes https://github.com/games647/FastLogin/issues/498
