### PR TITLE
Actually assign the queried version to a variable

### DIFF
--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
@@ -92,7 +92,7 @@ public class FastLoginBungee extends Plugin implements PlatformPlugin<CommandSen
         String floodgateVersion = "0";
         Plugin floodgatePlugin = pluginManager.getPlugin("floodgate");
         if (floodgatePlugin != null) {
-            floodgatePlugin.getDescription().getVersion();
+            floodgateVersion = floodgatePlugin.getDescription().getVersion();
         }
 
         ConnectListener connectListener = new ConnectListener(this, core.getRateLimiter(), floodgateVersion);


### PR DESCRIPTION
The Floodgate version was queried, but it's return value wasn't actually assigned to a variable.

Edited this from mobile GitHub website. I have no code check here.

[//]: # (Lines in this format are considered as comments and will not be displayed.)
[//]: # (If your work is in progress, please consider making a draft pull request.)

### Summary of your change
[//]: # (Example: motiviation, enhancement)

### Related issue
[//]: # (Reference it using '#NUMBER'. Ex: Fixes/Related #...)
