### PR TITLE
Add 'no-conflict' option to some Floodgate config entries

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
@@ -256,6 +256,7 @@ public class FastLoginBukkit extends JavaPlugin implements PlatformPlugin<Comman
 	 * <ul>
 	 * <li>allowFloodgateNameConflict
 	 * <li>autoLoginFloodgate
+	 * <li>autoRegisterFloodgate
 	 * </ul>
 	 * </p>
 	 * 
@@ -264,7 +265,7 @@ public class FastLoginBukkit extends JavaPlugin implements PlatformPlugin<Comman
 	 */
 	private boolean isValidFloodgateConfigString(String key) {
 		String value = core.getConfig().get(key).toString().toLowerCase();
-		if (!value.equals("true") && !value.equals("linked") && !value.equals("false")) {
+		if (!value.equals("true") && !value.equals("linked") && !value.equals("false") && !value.equals("no-conflict")) {
 			logger.error("Invalid value detected for {} in FastLogin/config.yml.", key);
 			return false;
 		}

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
@@ -76,7 +76,10 @@ public class FloodgateAuthTask implements Runnable {
         }
 
         //decide if checks should be made for conflicting Java player names
-        if (!isLinked &&
+        if (!isLinked //linked players have the same name as their Java profile
+                // if allowNameConflict is 'false' or 'linked' and the player had a conflicting
+                // name, than they would have been kicked in FloodgateHook#checkNameConflict
+                && allowNameConflict.equals("true") &&
                 (
                         autoLoginFloodgate.equals("no-conflict")
                         || !isRegistered && autoRegisterFloodgate.equals("no-conflict"))

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
@@ -76,8 +76,11 @@ public class FloodgateAuthTask implements Runnable {
         }
 
         //decide if checks should be made for conflicting Java player names
-        if (autoLoginFloodgate.equals("no-conflict")
-                || !isRegistered && autoRegisterFloodgate.equals("no-conflict")) {
+        if (!isLinked &&
+                (
+                        autoLoginFloodgate.equals("no-conflict")
+                        || !isRegistered && autoRegisterFloodgate.equals("no-conflict"))
+                ) {
             // check for conflicting Premium Java name
             Optional<Profile> premiumUUID = Optional.empty();
             try {

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
@@ -59,7 +59,6 @@ public class FloodgateAuthTask implements Runnable {
 
         // check if the Bedrock player is linked to a Java account 
         boolean isLinked = floodgatePlayer.getLinkedPlayer() != null;
-
         AuthPlugin<Player> authPlugin = plugin.getCore().getAuthPluginHook();
 
         String autoLoginFloodgate = plugin.getCore().getConfig().get("autoLoginFloodgate").toString().toLowerCase();
@@ -75,7 +74,7 @@ public class FloodgateAuthTask implements Runnable {
                     player.getName());
             return;
         }
-        
+
         //decide if checks should be made for conflicting Java player names
         if (autoLoginFloodgate.equals("no-conflict")
                 || !isRegistered && autoRegisterFloodgate.equals("no-conflict")) {
@@ -101,7 +100,7 @@ public class FloodgateAuthTask implements Runnable {
                     "Auto registration is disabled for Floodgate players in config.yml");
             return;
         }
-        
+
         // logging in from bedrock for a second time threw an error with UUID
         StoredProfile profile = plugin.getCore().getStorage().loadProfile(player.getName());
         if (profile == null) {
@@ -109,7 +108,7 @@ public class FloodgateAuthTask implements Runnable {
         }
 
         BukkitLoginSession session = new BukkitLoginSession(player.getName(), isRegistered, profile);
-        
+
         // enable auto login based on the value of 'autoLoginFloodgate' in config.yml
         session.setVerified(autoLoginFloodgate.equals("true")
                 || (autoLoginFloodgate.equals("linked") && isLinked));

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ThreadFactory;
 
-import net.md_5.bungee.BungeeServerInfo;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.PendingConnection;

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -194,9 +194,11 @@ autoLogin: true
 # !!!!!!!! WARNING: FLOODGATE SUPPORT IS AN EXPERIMENTAL FEATURE !!!!!!!!
 # Enabling any of these settings might lead to people gaining unauthorized access to other's accounts!
 
-# This enables auto login for every player connecting through Floodgate.
-# Possible values: false, true, linked
-# Linked means that only Bedrock accounts linked to a Java account will be logged in automatically
+# Automatically log in players connecting through Floodgate.
+# Possible values:
+#   false: Disables auto login for every player connecting through Floodgate
+#   true: Enables auto login for every player connecting through Floodgate
+#   linked: Only Bedrock accounts that are linked to a Java account will be logged in automatically
 # !!!!!!!! WARNING: FLOODGATE SUPPORT IS AN EXPERIMENTAL FEATURE !!!!!!!!
 # Enabling this might lead to people gaining unauthorized access to other's accounts!
 autoLoginFloodgate: false
@@ -225,8 +227,11 @@ autoLoginFloodgate: false
 # Enabling this might lead to people gaining unauthorized access to other's accounts!
 allowFloodgateNameConflict: false
 
-# This enables auto registering every player connecting through Floodgate.
+# Automatically register players connecting through Floodgate.
 # autoLoginFloodgate must be 'true' for this to work
+# Possible values:
+#   false: Disables auto registering for every player connecting through Floodgate
+#   true: Enables auto registering for every player connecting through Floodgate
 # !!!!!!!! WARNING: FLOODGATE SUPPORT IS AN EXPERIMENTAL FEATURE !!!!!!!!
 # Enabling this might lead to people gaining unauthorized access to other's accounts!
 autoRegisterFloodgate: false

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -199,6 +199,9 @@ autoLogin: true
 #   false: Disables auto login for every player connecting through Floodgate
 #   true: Enables auto login for every player connecting through Floodgate
 #   linked: Only Bedrock accounts that are linked to a Java account will be logged in automatically
+#   no-conflict: Bedrock players will only be automatically logged in if the Mojang API reports
+#     that there is no existing Premium Java MC account with their name.
+#     This option can be useful if you are not using 'username-prefix' in floodgate/config.yml
 # !!!!!!!! WARNING: FLOODGATE SUPPORT IS AN EXPERIMENTAL FEATURE !!!!!!!!
 # Enabling this might lead to people gaining unauthorized access to other's accounts!
 autoLoginFloodgate: false
@@ -228,10 +231,13 @@ autoLoginFloodgate: false
 allowFloodgateNameConflict: false
 
 # Automatically register players connecting through Floodgate.
-# autoLoginFloodgate must be 'true' for this to work
+# autoLoginFloodgate must be available for the player to use this
 # Possible values:
 #   false: Disables auto registering for every player connecting through Floodgate
 #   true: Enables auto registering for every player connecting through Floodgate
+#   no-conflict: Bedrock players will only be automatically registered if the Mojang API reports
+#     that there is no existing Premium Java MC account with their name.
+#     This option can be useful if you are not using 'username-prefix' in floodgate/config.yml
 # !!!!!!!! WARNING: FLOODGATE SUPPORT IS AN EXPERIMENTAL FEATURE !!!!!!!!
 # Enabling this might lead to people gaining unauthorized access to other's accounts!
 autoRegisterFloodgate: false


### PR DESCRIPTION
### Summary of your change
Added a `no-conflict` option to `autoRegisterFloodgate` and `autoLoginFloodgate` in config.yml
If this value is used, the player will be only logged in / registered if no Premium Java MC account exists with their name.

### Related issue
Could be useful for https://github.com/games647/FastLogin/issues/493