### PR TITLE
Warn in config: linked players conflict their Java name

### DIFF
--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -217,6 +217,8 @@ autoLoginFloodgate: false
 # Possible values:
 #   false: Check for Premium Java name conflicts as described in 'autoRegister'
 #     'autoRegister' must be 'true' for this to work
+#     Note: Linked players have the same name as their Java profile, so the Bedrock player will always conflict
+#     their own Java account's name. Therefore, setting this to false will prevent any linked player from joining.
 #   true:  Bypass 'autoRegister's name conflict checking 
 #   linked: Bedrock accounts linked to a Java account will be allowed to join with conflicting names
 # !!!!!!!! WARNING: FLOODGATE SUPPORT IS AN EXPERIMENTAL FEATURE !!!!!!!!


### PR DESCRIPTION
### Summary of your change
Add the following warning to `allowFloodgateNameConflict` in config.yml
> Linked players have the same name as their Java profile, so the Bedrock player will always conflict#     their own Java account's name. Therefore, setting this to false will prevent any linked player from joining.

I've decided to keep the default value `false` because in it's current state, Floodgate integration might have unknown bugs, and `false` is the safest value. This should be changed in the future. Or should I change it now?