### PR TITLE
Get rid of several warning messages

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/BukkitLoginSession.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/BukkitLoginSession.java
@@ -40,34 +40,32 @@ public class BukkitLoginSession extends LoginSession {
 
     private static final byte[] EMPTY_ARRAY = {};
 
-    private final String serverId;
     private final byte[] verifyToken;
 
     private boolean verified;
 
     private SkinProperty skinProperty;
 
-    public BukkitLoginSession(String username, String serverId, byte[] verifyToken, boolean registered
+    public BukkitLoginSession(String username, byte[] verifyToken, boolean registered
             , StoredProfile profile) {
         super(username, registered, profile);
 
-        this.serverId = serverId;
         this.verifyToken = verifyToken.clone();
     }
 
     //available for BungeeCord
     public BukkitLoginSession(String username, boolean registered) {
-        this(username, "", EMPTY_ARRAY, registered, null);
+        this(username, EMPTY_ARRAY, registered, null);
     }
 
     //cracked player
     public BukkitLoginSession(String username, StoredProfile profile) {
-        this(username, "", EMPTY_ARRAY, false, profile);
+        this(username, EMPTY_ARRAY, false, profile);
     }
 
     //ProtocolSupport
     public BukkitLoginSession(String username, boolean registered, StoredProfile profile) {
-        this(username, "", EMPTY_ARRAY, registered, profile);
+        this(username, EMPTY_ARRAY, registered, profile);
     }
 
     /**

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/BukkitScheduler.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/BukkitScheduler.java
@@ -36,12 +36,10 @@ import org.slf4j.Logger;
 
 public class BukkitScheduler extends AsyncScheduler {
 
-    private final Plugin plugin;
     private final Executor syncExecutor;
 
     public BukkitScheduler(Plugin plugin, Logger logger, ThreadFactory threadFactory) {
         super(logger, threadFactory);
-        this.plugin = plugin;
 
         syncExecutor = r -> Bukkit.getScheduler().runTask(plugin, r);
     }

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
@@ -48,12 +48,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.bukkit.Bukkit;
-import org.bukkit.Server.Spigot;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.geysermc.floodgate.api.FloodgateApi;
 import org.slf4j.Logger;
 
 /**

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/command/PremiumCommand.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/command/PremiumCommand.java
@@ -31,7 +31,6 @@ import com.github.games647.fastlogin.core.StoredProfile;
 
 import java.util.UUID;
 
-import com.github.games647.fastlogin.core.shared.event.FastLoginPremiumToggleEvent;
 import com.github.games647.fastlogin.core.shared.event.FastLoginPremiumToggleEvent.PremiumToggleReason;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/hook/UltraAuthHook.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/hook/UltraAuthHook.java
@@ -33,9 +33,7 @@ import java.util.concurrent.Future;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 import ultraauth.api.UltraAuthAPI;
-import ultraauth.main.Main;
 import ultraauth.managers.PlayerManager;
 
 /**
@@ -47,7 +45,6 @@ import ultraauth.managers.PlayerManager;
  */
 public class UltraAuthHook implements AuthPlugin<Player> {
 
-    private final Plugin ultraAuthPlugin = Main.main;
     private final FastLoginBukkit plugin;
 
     public UltraAuthHook(FastLoginBukkit plugin) {

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/NameCheckTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/NameCheckTask.java
@@ -104,10 +104,9 @@ public class NameCheckTask extends JoinManagement<Player, CommandSender, Protoco
         String ip = player.getAddress().getAddress().getHostAddress();
         core.getPendingLogin().put(ip + username, new Object());
 
-        String serverId = source.getServerId();
         byte[] verify = source.getVerifyToken();
 
-        BukkitLoginSession playerSession = new BukkitLoginSession(username, serverId, verify, registered, profile);
+        BukkitLoginSession playerSession = new BukkitLoginSession(username, verify, registered, profile);
         plugin.putSession(player.getAddress(), playerSession);
         //cancel only if the player has a paid account otherwise login as normal offline player
         synchronized (packetEvent.getAsyncMarker().getProcessingLock()) {

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocolsupport/ProtocolSupportListener.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocolsupport/ProtocolSupportListener.java
@@ -37,7 +37,6 @@ import com.github.games647.fastlogin.core.shared.event.FastLoginPreLoginEvent;
 import java.net.InetSocketAddress;
 import java.util.Optional;
 
-import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
@@ -59,8 +59,6 @@ import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.api.scheduler.GroupedThreadFactory;
 
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.slf4j.Logger;
 
 /**

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/hook/SodionAuthHook.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/hook/SodionAuthHook.java
@@ -32,8 +32,6 @@ import red.mohist.sodionauth.bungee.implementation.BungeePlayer;
 import red.mohist.sodionauth.core.SodionAuthApi;
 import red.mohist.sodionauth.core.exception.AuthenticatedException;
 
-import java.util.concurrent.ExecutionException;
-
 /**
  * GitHub: https://github.com/Mohist-Community/SodionAuth
  * <p>

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
@@ -58,7 +58,6 @@ import net.md_5.bungee.connection.LoginResult.Property;
 import net.md_5.bungee.event.EventHandler;
 import net.md_5.bungee.event.EventPriority;
 
-import org.geysermc.floodgate.FloodgateAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
@@ -101,13 +101,11 @@ public class ConnectListener implements Listener {
     private final FastLoginBungee plugin;
     private final RateLimiter rateLimiter;
     private final Property[] emptyProperties = {};
-    private final String floodgateVersion;
     private final FloodgateHook floodgateHook;
 
     public ConnectListener(FastLoginBungee plugin, RateLimiter rateLimiter, String floodgateVersion) {
         this.plugin = plugin;
         this.rateLimiter = rateLimiter;
-        this.floodgateVersion = floodgateVersion;
 
         // Get the appropriate floodgate api hook based on the version
         if (floodgateVersion.startsWith("1")) {

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
@@ -73,12 +73,10 @@ public class ConnectListener implements Listener {
 
     static {
         MethodHandle setHandle = null;
-        boolean handlerFound = false;
         try {
             Lookup lookup = MethodHandles.lookup();
 
             Class.forName("net.md_5.bungee.connection.InitialHandler");
-            handlerFound = true;
 
             Field uuidField = InitialHandler.class.getDeclaredField(UUID_FIELD_NAME);
             uuidField.setAccessible(true);

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
@@ -69,7 +69,6 @@ import org.slf4j.LoggerFactory;
 public class ConnectListener implements Listener {
 
     private static final String UUID_FIELD_NAME = "uniqueId";
-    private static final boolean initialHandlerClazzFound;
     private static final MethodHandle uniqueIdSetter;
 
     static {
@@ -94,7 +93,6 @@ public class ConnectListener implements Listener {
             reflectiveOperationException.printStackTrace();
         }
 
-        initialHandlerClazzFound = handlerFound;
         uniqueIdSetter = setHandle;
     }
 

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/AsyncToggleMessage.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/AsyncToggleMessage.java
@@ -30,7 +30,6 @@ import com.github.games647.fastlogin.bungee.event.BungeeFastLoginPremiumToggleEv
 import com.github.games647.fastlogin.core.StoredProfile;
 import com.github.games647.fastlogin.core.shared.FastLoginCore;
 
-import com.github.games647.fastlogin.core.shared.event.FastLoginPremiumToggleEvent;
 import com.github.games647.fastlogin.core.shared.event.FastLoginPremiumToggleEvent.PremiumToggleReason;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;


### PR DESCRIPTION
### Summary of your change
Remove unused variables and imports.
Every warning fix is in a separate commit (except for the imports), so it'll be easier to revert one of them, if they'd be useful in the future. If one (or more) of them is needed, then I'll revert it.

### Related issue
The IDE will throw less warnings. It really annoyed me, but I didn't want to hide these commits in another PR, so I've made a separate PR.