### PR TITLE
FloodgateNameConflict no longer needs autoLogin

### DIFF
--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -221,7 +221,6 @@ autoLoginFloodgate: false
 #
 # Possible values:
 #   false: Check for Premium Java name conflicts as described in 'autoRegister'
-#     'autoRegister' must be 'true' for this to work
 #     Note: Linked players have the same name as their Java profile, so the Bedrock player will always conflict
 #     their own Java account's name. Therefore, setting this to false will prevent any linked player from joining.
 #   true:  Bypass 'autoRegister's name conflict checking 


### PR DESCRIPTION
The removed line is not valid after https://github.com/games647/FastLogin/commit/1f3cd5fa5b6a2d94106ef6c90af8fa92fb5ef36c

[//]: # (Lines in this format are considered as comments and will not be displayed.)
[//]: # (If your work is in progress, please consider making a draft pull request.)

### Summary of your change
[//]: # (Example: motiviation, enhancement)
Removed an unnecessary line from config.yml
### Related issue
[//]: # (Reference it using '#NUMBER'. Ex: Fixes/Related #...)
