### PR TITLE
Add 'linked' option to 'autoRegisterFloodgate'

### DIFF
--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
@@ -105,7 +105,7 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
             }
         }
 
-        if (!isRegistered && autoRegisterFloodgate.equals("false")) {
+        if (!isRegistered && !isAutoRegisterAllowed()) {
             return;
         }
 
@@ -118,6 +118,17 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
         //start Bukkit/Bungee specific tasks
         startLogin();
 
+    }
+
+    /**
+     * Decude if the player can be auto registered.
+     * The config option 'non-conflicting' is ignored by this function.
+     * @return true if the Player can be registered automatically
+     */
+    private boolean isAutoRegisterAllowed() {
+        return autoRegisterFloodgate.equals("true") 
+                || autoRegisterFloodgate.equals("no-conflict") // this was checked before
+                || (autoRegisterFloodgate.equals("linked") && isLinked);
     }
 
     /**

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -234,6 +234,7 @@ allowFloodgateNameConflict: false
 # Possible values:
 #   false: Disables auto registering for every player connecting through Floodgate
 #   true: Enables auto registering for every player connecting through Floodgate
+#   linked: Only Bedrock accounts that are linked to a Java account will be registered automatically
 #   no-conflict: Bedrock players will only be automatically registered if the Mojang API reports
 #     that there is no existing Premium Java MC account with their name.
 #     This option can be useful if you are not using 'username-prefix' in floodgate/config.yml


### PR DESCRIPTION
### Summary of your change
There is a new option available in `config.yml` for `autoRegisterFloodgate`:
https://github.com/games647/FastLogin/blob/2b7800e138ebc5b12c7095abef8a77d02a715536/core/src/main/resources/config.yml#L237

This option makes sense with Floodgate 2.0's [Global Link API](https://github.com/GeyserMC/Floodgate/wiki/Features#what-is-the-global-api)

### Related issue
None