### PR TITLE
Update messages

### DIFF
--- a/core/src/main/java/com/github/games647/fastlogin/core/hooks/FloodgateHook.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/hooks/FloodgateHook.java
@@ -69,17 +69,18 @@ public class FloodgateHook<P extends C, C, S extends LoginSource> {
                         "Could not check wether Floodgate Player {}'s name conflicts a premium Java player's name.",
                         username);
                 try {
-                    source.kick("Could not check if your name conflicts an existing Java Premium Player's name");
+                    source.kick("Could not check if your name conflicts an existing premium Java account's name.\n"
+                            + "This is usually a serverside error.");
                 } catch (Exception e1) {
                     core.getPlugin().getLog().error("Could not kick Player {}", username);
                 }
             }
 
             if (premiumUUID.isPresent()) {
-                core.getPlugin().getLog().info("Bedrock Player {}'s name conflicts an existing Java Premium Player's name",
+                core.getPlugin().getLog().info("Bedrock Player {}'s name conflicts an existing premium Java account's name",
                         username);
                 try {
-                    source.kick("Your name conflicts an existing Java Premium Player's name");
+                    source.kick("Your name conflicts an existing premium Java account's name");
                 } catch (Exception e) {
                     core.getPlugin().getLog().error("Could not kick Player {}", username);
                 }

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
@@ -94,7 +94,7 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
                 premiumUUID = core.getResolver().findProfile(username);
             } catch (IOException | RateLimitException e) {
                 core.getPlugin().getLog().error(
-                        "Could not check wether Floodgate Player {}'s name conflits a premium Java player's name.",
+                        "Could not check wether Floodgate Player {}'s name conflits a premium Java account's name.",
                         username);
                 return;
             }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -189,7 +189,6 @@ autoLogin: true
 
 # Floodgate configuration
 # Connecing through Floodgate requires player's to sign in via their Xbox Live account
-# Requires Floodgate 2.0 https://github.com/GeyserMC/Floodgate/tree/dev/2.0
 # !!!!!!!! WARNING: FLOODGATE SUPPORT IS AN EXPERIMENTAL FEATURE !!!!!!!!
 # Enabling any of these settings might lead to people gaining unauthorized access to other's accounts!
 


### PR DESCRIPTION
[//]: # (Lines in this format are considered as comments and will not be displayed.)
[//]: # (If your work is in progress, please consider making a draft pull request.)

### Summary of your change
- Removed outdated Floodgate 2.0 link from config.yml
- Replaced the word `Player` with the word `Account` in several messages.
Technically speaking, one player can own both the Java and the Bedrock account with the same name, so it's more appropriate to say account instead of player.


### Related issue
None
