### PR TITLE
Workaround for Floodgate prefixes with ProtocolLlib

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
@@ -25,10 +25,12 @@
  */
 package com.github.games647.fastlogin.bukkit;
 
+import com.comphenix.protocol.ProtocolLibrary;
 import com.github.games647.fastlogin.bukkit.command.CrackedCommand;
 import com.github.games647.fastlogin.bukkit.command.PremiumCommand;
 import com.github.games647.fastlogin.bukkit.listener.ConnectionListener;
 import com.github.games647.fastlogin.bukkit.listener.PaperCacheListener;
+import com.github.games647.fastlogin.bukkit.listener.protocollib.ManualNameChange;
 import com.github.games647.fastlogin.bukkit.listener.protocollib.ProtocolLibListener;
 import com.github.games647.fastlogin.bukkit.listener.protocollib.SkinApplyListener;
 import com.github.games647.fastlogin.bukkit.listener.protocolsupport.ProtocolSupportListener;
@@ -115,6 +117,8 @@ public class FastLoginBukkit extends JavaPlugin implements PlatformPlugin<Comman
                 pluginManager.registerEvents(new ProtocolSupportListener(this, core.getRateLimiter()), this);
             } else if (pluginManager.isPluginEnabled("ProtocolLib")) {
                 ProtocolLibListener.register(this, core.getRateLimiter());
+                //TODO: make configurable & check if it's needed
+                ProtocolLibrary.getProtocolManager().addPacketListener(new ManualNameChange(this));
 
                 //if server is using paper - we need to set the skin at pre login anyway, so no need for this listener
                 if (!PaperLib.isPaper() && getConfig().getBoolean("forwardSkin")) {

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
@@ -117,8 +117,21 @@ public class FastLoginBukkit extends JavaPlugin implements PlatformPlugin<Comman
                 pluginManager.registerEvents(new ProtocolSupportListener(this, core.getRateLimiter()), this);
             } else if (pluginManager.isPluginEnabled("ProtocolLib")) {
                 ProtocolLibListener.register(this, core.getRateLimiter());
-                //TODO: make configurable & check if it's needed
-                ProtocolLibrary.getProtocolManager().addPacketListener(new ManualNameChange(this));
+
+                if (isPluginInstalled("floodgate")) {
+                    if (getConfig().getBoolean("floodgatePrefixWorkaround")){
+                        ProtocolLibrary.getProtocolManager().addPacketListener(new ManualNameChange(this));
+                        logger.info("Floodgate prefix injection workaround has been enabled.");
+                        logger.info("If you have problems joining the server, try disabling it in the configuration.");
+                    } else {
+                        logger.warn("We have detected that you are runnging FastLogin alongside Floodgate and ProtocolLib.");
+                        logger.warn("Currently there is an issue with FastLogin that prevents Floodgate name prefixes from showing up "
+                                + "when it is together used with ProtocolLib.");
+                        logger.warn("If you would like to use Floodgate name prefixes, you can enable an experimental workaround by changing "
+                                + "the value 'floodgatePrefixWorkaround' to true in config.yml.");
+                        logger.warn("For more information visit https://github.com/games647/FastLogin/issues/493");
+                    }
+                }
 
                 //if server is using paper - we need to set the skin at pre login anyway, so no need for this listener
                 if (!PaperLib.isPaper() && getConfig().getBoolean("forwardSkin")) {
@@ -315,13 +328,6 @@ public class FastLoginBukkit extends JavaPlugin implements PlatformPlugin<Comman
                     + "Floodgate 2.0 from https://ci.opencollab.dev/job/GeyserMC/job/Floodgate/job/dev%252F2.0/");
             logger.warn("Don't forget to update Geyser to a supported version as well from "
                     + "https://ci.opencollab.dev/job/GeyserMC/job/Geyser/job/floodgate-2.0/");
-    	} else if (isPluginInstalled("floodgate") && isPluginInstalled("ProtocolLib")) {
-            logger.warn("We have detected that you are running FastLogin alongside Floodgate and ProtocolLib.");
-            logger.warn("Currently there is an issue with FastLogin that prevents Floodgate's name prefixes from " +
-                    "showing up when it is together used with ProtocolLib.");
-            logger.warn("If you would like to use Floodgate name prefixes, you can replace ProtocolLib with " +
-                    "ProtocolSupport which does not have this issue.");
-            logger.warn("For more information visit https://github.com/games647/FastLogin/issues/493");
     	}
     }
 }

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
@@ -120,7 +120,7 @@ public class FastLoginBukkit extends JavaPlugin implements PlatformPlugin<Comman
 
                 if (isPluginInstalled("floodgate")) {
                     if (getConfig().getBoolean("floodgatePrefixWorkaround")){
-                        ProtocolLibrary.getProtocolManager().addPacketListener(new ManualNameChange(this));
+                        ProtocolLibrary.getProtocolManager().addPacketListener(new ManualNameChange(this, floodgateService));
                         logger.info("Floodgate prefix injection workaround has been enabled.");
                         logger.info("If you have problems joining the server, try disabling it in the configuration.");
                     } else {

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ManualNameChange.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ManualNameChange.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2021 <Your name and contributors>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.games647.fastlogin.bukkit.listener.protocollib;
+
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.WrappedGameProfile;
+import com.github.games647.fastlogin.bukkit.FastLoginBukkit;
+
+import org.geysermc.floodgate.api.FloodgateApi;
+
+import static com.comphenix.protocol.PacketType.Login.Client.START;
+
+/**
+ * Manually inject Floodgate player name prefixes.
+ * <br>
+ * This is used as a workaround, because Floodgate fails to inject
+ * the prefixes when it's used together with ProtocolLib and FastLogin.
+ * <br>
+ * For more information visit: https://github.com/games647/FastLogin/issues/493
+ */
+public class ManualNameChange extends PacketAdapter {
+
+    public ManualNameChange(FastLoginBukkit plugin) {
+        super(params()
+                .plugin(plugin)
+                .types(START));
+
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void onPacketReceiving(PacketEvent packetEvent) {
+        PacketContainer packet = packetEvent.getPacket();
+        WrappedGameProfile originalProfile = packet.getGameProfiles().read(0);
+        packet.setMeta("original_name", originalProfile.getName());
+        String prefixedName = FloodgateApi.getInstance().getPlayerPrefix() + originalProfile.getName();
+        WrappedGameProfile updatedProfile = originalProfile.withName(prefixedName);
+        packet.getGameProfiles().write(0, updatedProfile);
+    }
+}

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ProtocolLibListener.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ProtocolLibListener.java
@@ -124,6 +124,12 @@ public class ProtocolLibListener extends PacketAdapter {
         PacketContainer packet = packetEvent.getPacket();
 
         String username = packet.getGameProfiles().read(0).getName();
+
+        if (packetEvent.getPacket().getMeta("original_name").isPresent()) {
+            //username has been injected by ManualNameChange.java
+            username = (String) packetEvent.getPacket().getMeta("original_name").get();
+        }
+
         plugin.getLog().trace("GameProfile {} with {} connecting", sessionKey, username);
 
         packetEvent.getAsyncMarker().incrementProcessingDelay();

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -214,9 +214,8 @@ autoLoginFloodgate: false
 #
 # To prevent conflits from two different players having the same name, it is highly recommended to use a 'username-prefix'
 # in floodgate/config.yml
-# Note: 'username-prefix' is currently broken when used with FastLogin and ProtocolLib. For more information visit:
-#   https://github.com/games647/FastLogin/issues/493
-# A solution to this is to replace ProtocolLib with ProtocolSupport
+# Note: 'username-prefix' is currently broken when used with FastLogin and ProtocolLib.
+# A solution to this is to enable 'floodgatePrefixWorkaround' below.
 #
 # Possible values:
 #   false: Kick Bedrock players, if they are using an existing Premium Java account's name
@@ -242,6 +241,14 @@ allowFloodgateNameConflict: false
 # !!!!!!!! WARNING: FLOODGATE SUPPORT IS AN EXPERIMENTAL FEATURE !!!!!!!!
 # Enabling this might lead to people gaining unauthorized access to other's accounts!
 autoRegisterFloodgate: false
+
+# Make FastLogin inject the Floodgate name prefixes, instead of Floodgate.
+# This can fix prefixes, if you are using Floodgate alongside ProtocolLib.
+# If either of those plugins are not installed, this option will have no effect.
+# For more information visit: https://github.com/games647/FastLogin/issues/493
+# !!!!!!!! WARNING: FLOODGATE SUPPORT IS AN EXPERIMENTAL FEATURE !!!!!!!!
+# Enabling this might lead to people gaining unauthorized access to other's accounts!
+floodgatePrefixWorkaround: false
 
 # Database configuration
 # Recommended is the use of MariaDB (a better version of MySQL)


### PR DESCRIPTION
### Summary of your change
Made FastLogin add Floodgate player name prefixes, if Floodgate fails to do it.
Added `floodgatePrefixWorkaround` to config.yml to enable or disable this feature.

### Related issue
Proposes a workaround / fixes https://github.com/games647/FastLogin/issues/493

### Notes
This will leave [Floodgate/SpigotDataHandler.java](https://github.com/GeyserMC/Floodgate/blob/821be02bdb179f7d4ba7b0ec79bbc721c28105f5/spigot/src/main/java/org/geysermc/floodgate/addon/data/SpigotDataHandler.java) in a limbo state, so it'll run some code (mostly if checks to decide if it's receiving a login packet) but it didn't have a noticeable impact on performance and it also seemed to be stable.