### PR TITLE
Fix plugin messages for Floodgate players

### DIFF
--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/PluginMessageListener.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/PluginMessageListener.java
@@ -36,6 +36,9 @@ import com.github.games647.fastlogin.core.shared.FastLoginCore;
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteStreams;
 
+import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.floodgate.api.player.FloodgatePlayer;
+
 import java.util.Arrays;
 
 import net.md_5.bungee.api.CommandSender;
@@ -115,7 +118,13 @@ public class PluginMessageListener implements Listener {
     }
 
     private void onSuccessMessage(ProxiedPlayer forPlayer) {
-        if (forPlayer.getPendingConnection().isOnlineMode()) {
+        //check if player is using Floodgate
+        FloodgatePlayer floodgatePlayer = null;
+        if (plugin.isPluginInstalled("floodgate")) {
+            floodgatePlayer = FloodgateApi.getInstance().getPlayer(forPlayer.getUniqueId());
+        }
+
+        if (forPlayer.getPendingConnection().isOnlineMode() || floodgatePlayer != null){
             //bukkit module successfully received and force logged in the user
             //update only on success to prevent corrupt data
             BungeeLoginSession loginSession = plugin.getSession().get(forPlayer.getPendingConnection());

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
@@ -73,10 +73,20 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
 
         // check if the Bedrock player is linked to a Java account 
         isLinked = floodgatePlayer.getLinkedPlayer() != null;
+        profile = core.getStorage().loadProfile(username);
         AuthPlugin<P> authPlugin = core.getAuthPluginHook();
-        
+
         try {
-            isRegistered = authPlugin.isRegistered(username);
+            //maybe Bungee without auth plugin
+            if (authPlugin == null) {
+                if (profile != null) {
+                    isRegistered = profile.isPremium();
+                } else {
+                    isRegistered = false;
+                }
+            } else {
+                isRegistered = authPlugin.isRegistered(username);
+            }
         } catch (Exception ex) {
             core.getPlugin().getLog().error(
                     "An error has occured while checking if player {} is registered",
@@ -108,7 +118,6 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
         }
 
         //logging in from bedrock for a second time threw an error with UUID
-        profile = core.getStorage().loadProfile(username);
         if (profile == null) {
             profile = new StoredProfile(getUUID(player), username, true, getAddress(player).toString());
         }


### PR DESCRIPTION
### Summary of your change
Previously registration checks for Floodgate players were made via, `authPlugin.isRegistered(username)`. However, if no auth plugin is installed, that it would have obviously failed. With this PR, if there's no such plugin, it'll try to get the registration status from the SQL Database.

### Related issue
Fixes #594 

I got a lot of `java.lang.IllegalStateException: Cannot reply to EncryptionRequestPacket without profile and access token.` errors while trying to join via Bungeecord. It happens randomly (around 50% of the time), if the player is not yet in the `Floodgate.getPlayers()` list when doing the name conflict checking:
https://github.com/games647/FastLogin/blob/01c9b55d80c93e0df4ad9050519995f4d56db759/core/src/main/java/com/github/games647/fastlogin/core/shared/JoinManagement.java#L61

This error is unrelated to the files modified in this PR, so I thought that I'd open ~~a second PR with the fix~~ #603 because I couldn't figure it out.