### PR TITLE
Don't crash if no storage is loaded

### DIFF
--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
@@ -73,6 +73,13 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
 
         // check if the Bedrock player is linked to a Java account 
         isLinked = floodgatePlayer.getLinkedPlayer() != null;
+
+        //this happens on Bukkit if it's connected to Bungee
+        //if that's the case, players will be logged in via plugin messages
+        if (core.getStorage() == null) {
+            return;
+        }
+
         profile = core.getStorage().loadProfile(username);
         AuthPlugin<P> authPlugin = core.getAuthPluginHook();
 


### PR DESCRIPTION


[//]: # (Lines in this format are considered as comments and will not be displayed.)
[//]: # (If your work is in progress, please consider making a draft pull request.)

### Summary of your change
[//]: # (Example: motiviation, enhancement)
If the pluign is running on Bukkit, and it's connected to Bungee
then core.getStorage() will be null.
If that's the case, players will be logged in via a plugin messages.
### Related issue
[//]: # (Reference it using '#NUMBER'. Ex: Fixes/Related #...)
https://github.com/games647/FastLogin/pull/602#issuecomment-905740940