### PR TITLE
Delay Floodgate name checks on BungeeCord

### DIFF
--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -141,6 +141,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Bedrock player bridge for low level checks -->
+        <dependency>
+            <groupId>org.geysermc</groupId>
+            <artifactId>connector</artifactId>
+            <version>1.2.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!--Login plugin-->
         <dependency>
             <groupId>me.vik1395</groupId>

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/BungeeFloodgateLoginSource.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/BungeeFloodgateLoginSource.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2021 <Your name and contributors>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.games647.fastlogin.bungee;
+
+import com.github.games647.fastlogin.core.shared.LoginSource;
+
+import java.net.InetSocketAddress;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.connection.PendingConnection;
+import net.md_5.bungee.api.event.LoginEvent;
+
+public class BungeeFloodgateLoginSource implements LoginSource {
+
+    private final PendingConnection connection;
+    private final LoginEvent loginEvent;
+
+    public BungeeFloodgateLoginSource(PendingConnection connection, LoginEvent loginEvent) {
+        this.connection = connection;
+        this.loginEvent = loginEvent;
+    }
+
+    @Override
+    public void enableOnlinemode() {
+        connection.setOnlineMode(true);
+    }
+
+    @Override
+    public void kick(String message) {
+        loginEvent.setCancelled(true);
+
+        if (message == null) {
+            loginEvent.setCancelReason(new ComponentBuilder("Kicked").color(ChatColor.WHITE).create());
+        } else {
+            loginEvent.setCancelReason(TextComponent.fromLegacyText(message));
+        }
+    }
+
+    @Override
+    public InetSocketAddress getAddress() {
+        return connection.getAddress();
+    }
+
+    public PendingConnection getConnection() {
+        return connection;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + '{' +
+                "connection=" + connection +
+                '}';
+    }
+}

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/BungeeLoginSession.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/BungeeLoginSession.java
@@ -33,8 +33,16 @@ public class BungeeLoginSession extends LoginSession {
     private boolean alreadySaved;
     private boolean alreadyLogged;
 
-    public BungeeLoginSession(String username, boolean registered, StoredProfile profile) {
+    //this will be true, if the Floodgate name conflict checks were skipped in PreLoginEvent
+    private boolean floodgateCheckSkipped;
+
+    public BungeeLoginSession(String username, boolean registered, StoredProfile profile, boolean floodgateCheckSkipped) {
         super(username, registered, profile);
+        this.floodgateCheckSkipped = floodgateCheckSkipped;
+    }
+
+    public BungeeLoginSession(String username, boolean registered, StoredProfile profile) {
+        this(username, registered, profile, false);
     }
 
     public synchronized void setRegistered(boolean registered) {
@@ -64,5 +72,13 @@ public class BungeeLoginSession extends LoginSession {
                 ", alreadyLogged=" + alreadyLogged +
                 ", registered=" + registered +
                 "} " + super.toString();
+    }
+
+    public boolean isFloodgateCheckSkipped() {
+        return this.floodgateCheckSkipped;
+    }
+
+    public void setFloodgateCheckSkipped(boolean floodgateCheckSkipped) {
+        this.floodgateCheckSkipped = floodgateCheckSkipped;
     }
 }

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java
@@ -56,6 +56,8 @@ import net.md_5.bungee.connection.LoginResult.Property;
 import net.md_5.bungee.event.EventHandler;
 import net.md_5.bungee.event.EventPriority;
 
+import org.geysermc.connector.GeyserConnector;
+import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.floodgate.api.FloodgateApi;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.slf4j.Logger;
@@ -116,6 +118,18 @@ public class ConnectListener implements Listener {
 
         String username = connection.getName();
         plugin.getLog().info("Incoming login request for {} from {}", username, connection.getSocketAddress());
+
+        if (plugin.isPluginInstalled("Geyser-BungeeCord")) {
+            for (GeyserSession gSess : GeyserConnector.getInstance().getPlayers()) {
+                if (username.equals(FloodgateApi.getInstance().getPlayerPrefix() + gSess.getName())){
+                    //todo: if no Floodgate prefix is set, and there are name conflicts, how will this behave?
+                    plugin.getLog().info("Player {} is using Geyser. Name conflict checks will be done later.", username);
+                    StoredProfile profile = plugin.getCore().getStorage().loadProfile(username);
+                    plugin.getSession().put(connection, new BungeeLoginSession(username, true, profile, true));
+                    return;
+                }
+            }
+        }
 
         preLoginEvent.registerIntent(plugin);
         Runnable asyncPremiumCheck = new AsyncPremiumCheck(plugin, preLoginEvent, connection, username);


### PR DESCRIPTION
[//]: # (Lines in this format are considered as comments and will not be displayed.)
[//]: # (If your work is in progress, please consider making a draft pull request.)

### Summary of your change
[//]: # (Example: motiviation, enhancement)
The `FloodgateApi` returns `null` at `PreLoginEvent` so all Floodgate related checks have to be done at `LoginEvent`.

### Related issue
[//]: # (Reference it using '#NUMBER'. Ex: Fixes/Related #...)
Fixes https://github.com/games647/FastLogin/issues/603

### Why Draft?

- [ ] No one else has reported the issue, so there's no way to verify if it also affects other users.
- [ ] This is a fast workaround, so code quality is not the best. Please notify me about the necessary changes.
   I especially don't like how I had to create a new class for [BungeeFloodgateLoginSource](https://github.com/games647/FastLogin/blob/a46a5fb6116e3798689af53ae2ca75af7b1719ae/bungee/src/main/java/com/github/games647/fastlogin/bungee/BungeeFloodgateLoginSource.java), which is only used by 
https://github.com/games647/FastLogin/blob/a46a5fb6116e3798689af53ae2ca75af7b1719ae/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java#L159-L160
- [ ] Because of
https://github.com/games647/FastLogin/blob/a46a5fb6116e3798689af53ae2ca75af7b1719ae/bungee/src/main/java/com/github/games647/fastlogin/bungee/listener/ConnectListener.java#L132
- [ ] The skipped Floodgate checking code is still in core, it's just made unreachable via a `return` statement.
   _It was easier to make it stay there for now, because on Bukkit, there are two Protocol plugins, and both of them have to run the Floodgate checks._