### PR TITLE
Kick Java cracked user if it have the Floodgate Prefix

### DIFF
--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/JoinManagement.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/JoinManagement.java
@@ -34,6 +34,7 @@ import com.github.games647.fastlogin.core.shared.event.FastLoginPreLoginEvent;
 
 import java.util.Optional;
 
+import org.geysermc.floodgate.api.FloodgateApi;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 
 import net.md_5.bungee.config.Configuration;
@@ -76,6 +77,11 @@ public abstract class JoinManagement<P extends C, C, S extends LoginSource> {
                     core.getPlugin().getLog().info("Requesting premium login for registered player: {}", username);
                     requestPremiumLogin(source, profile, username, true);
                 } else {
+                    if (profile.getName().startsWith(FloodgateApi.getInstance().getPlayerPrefix())) {
+                        core.getPlugin().getLog().info("Floodgate Prefix detected on cracked player");
+                        source.kick("Your username contains illegal characters");
+                        return;
+                    }
                     startCrackedSession(source, profile, username);
                 }
             } else {


### PR DESCRIPTION
[//]: # (Lines in this format are considered as comments and will not be displayed.)
[//]: # (If your work is in progress, please consider making a draft pull request.)

### Summary of your change
[//]: # (Example: motiviation, enhancement)

With the actual code a cracked Java player can enter in the server with a username that contains a Floodgate prefix, like: ".Myusername" and he can register a new account, preventing a Floodgate user from registering.

The solution is to check the username of cracked users and kick the users who have a Floodgate prefix in the first character of the username.