### PR TITLE
Fix Floodgate player detection (caused by prefixes)

### DIFF
--- a/core/src/main/java/com/github/games647/fastlogin/core/hooks/FloodgateService.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/hooks/FloodgateService.java
@@ -130,11 +130,23 @@ public class FloodgateService {
      * The FloodgateApi does not support querying players by name, so this function
      * iterates over every online FloodgatePlayer and checks if the requested
      * username can be found
+     * <br>
+     * <i>Falls back to non-prefixed name checks, if ProtocolLib is installed</i>
      * 
      * @param prefixedUsername the name of the player with the prefix appended
      * @return FloodgatePlayer if found, null otherwise
      */
     public FloodgatePlayer getFloodgatePlayer(String prefixedUsername) {
+        //prefixes are broken with ProtocolLib, so fall back to name checks without prefixes
+        //this should be removed if #493 gets fixed
+        if (core.getPlugin().isPluginInstalled("ProtocolLib")) {
+            for (FloodgatePlayer floodgatePlayer : FloodgateApi.getInstance().getPlayers()) {
+                if (floodgatePlayer.getUsername().equals(prefixedUsername)) {
+                    return floodgatePlayer;
+                }
+            }
+            return null;
+        }
         for (FloodgatePlayer floodgatePlayer : FloodgateApi.getInstance().getPlayers()) {
             if (floodgatePlayer.getCorrectUsername().equals(prefixedUsername)) {
                 return floodgatePlayer;


### PR DESCRIPTION
### Summary of your change
So after implementing around half of the plans I've outlined in https://github.com/games647/FastLogin/pull/608#issuecomment-946910336, I've realized that most of them are either false, or unnecessary.
From my test concluded today, I've realized that Floodgate now appends the prefixes to every player by the time they reach JoinManagement. The only exception to this, is when https://github.com/games647/FastLogin/issues/493 occurs.
This PR makes JoinManagement use `FloodgateApi.getCorrectUsername()` instead of `FloodgateApi.getUsername()`.

### Related issue
Fixes https://github.com/games647/FastLogin/issues/603
Fixes https://github.com/games647/FastLogin/issues/616
Fixes https://github.com/games647/FastLogin/issues/630
Fixes https://github.com/games647/FastLogin/issues/632
