### PR TITLE
Fix "No Session" in plugin messaging

### DIFF
--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/FloodgateAuthTask.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/FloodgateAuthTask.java
@@ -53,6 +53,7 @@ public class FloodgateAuthTask
     @Override
     protected void startLogin() {
         BungeeLoginSession session = new BungeeLoginSession(player.getName(), isRegistered, profile);
+        core.getPlugin().getSession().put(player.getPendingConnection(), session);
 
         // enable auto login based on the value of 'autoLoginFloodgate' in config.yml
         boolean forcedOnlineMode = autoLoginFloodgate.equals("true")


### PR DESCRIPTION
### Summary of your change
After Bungee recieved a plugin message from Bukkit, that it has completed login/register for a Floodgate player, bungee would throw a NullPointerException: 
> java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "com.github.games647.fastlogin.bungee.BungeeLoginSession.getProfile()" because "loginSession" is null
        at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315) ~[?:?]
        at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320) ~[?:?]
        at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1807) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "com.github.games647.fastlogin.bungee.BungeeLoginSession.getProfile()" because "loginSession" is null
        at com.github.games647.fastlogin.bungee.listener.PluginMessageListener.onSuccessMessage(PluginMessageListener.java:131) ~[?:?]
        at com.github.games647.fastlogin.bungee.listener.PluginMessageListener.readMessage(PluginMessageListener.java:92) ~[?:?]
        at com.github.games647.fastlogin.bungee.listener.PluginMessageListener.lambda$onPluginMessage$0(PluginMessageListener.java:84) ~[?:?]
        at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[?:?]
        ... 3 more

### Related issue
Strangely, no one has reported this issue. It exist in yesterday's build , idk about later versions, I haven't tested it.
