### PR TITLE
Fix the bug with the lack of search accuracy in the session map.

### DIFF
--- a/velocity/src/main/java/com/github/games647/fastlogin/velocity/FastLoginVelocity.java
+++ b/velocity/src/main/java/com/github/games647/fastlogin/velocity/FastLoginVelocity.java
@@ -34,7 +34,8 @@ import com.github.games647.fastlogin.core.shared.FastLoginCore;
 import com.github.games647.fastlogin.core.shared.PlatformPlugin;
 import com.github.games647.fastlogin.velocity.listener.ConnectListener;
 import com.github.games647.fastlogin.velocity.listener.PluginMessageListener;
-import com.google.common.collect.MapMaker;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
@@ -59,6 +60,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
@@ -72,7 +74,9 @@ public class FastLoginVelocity implements PlatformPlugin<CommandSource> {
     private final ProxyServer server;
     private final Path dataDirectory;
     private final Logger logger;
-    private final ConcurrentMap<InetSocketAddress, VelocityLoginSession> session = new MapMaker().weakKeys().makeMap();
+    private final Cache<InetSocketAddress, VelocityLoginSession> session = CacheBuilder.newBuilder()
+            .expireAfterAccess(5, TimeUnit.MINUTES)
+            .build();
     private static final String PROXY_ID_fILE = "proxyId.txt";
 
     private FastLoginCore<Player, CommandSource, FastLoginVelocity> core;
@@ -149,7 +153,7 @@ public class FastLoginVelocity implements PlatformPlugin<CommandSource> {
     }
 
     public ConcurrentMap<InetSocketAddress, VelocityLoginSession> getSession() {
-        return session;
+        return session.asMap();
     }
 
     public ProxyServer getProxy() {


### PR DESCRIPTION
Linked bug: https://github.com/TCPShield/RealIP/pull/72 (a bug was found while fixing dynamic player IP changing)
## Problem
See `ConnectListener.onGameprofileRequest()` to know the context

print sessions map
`[map key] ? [current ip] -> compare by .equals()`
```
plugin.getSession().forEach((inetSocketAddress, velocityLoginSession) -> {
    System.err.println(inetSocketAddress.toString() + " ? " + event.getConnection().getRemoteAddress().toString() + " -> " + inetSocketAddress.equals(event.getConnection().getRemoteAddress()));
});
```
result:
```
 /5.173.249.24:39437 ? /5.173.249.24:30028 -> false
 /5.173.249.24:50033 ? /5.173.249.24:30028 -> false
 /5.173.249.24:39426 ? /5.173.249.24:30028 -> false
 /5.173.249.24:30028 ? /5.173.249.24:30028 -> true <- key is present
 /5.173.249.24:30045 ? /5.173.249.24:30028 -> false
 /5.173.249.24:23523 ? /5.173.249.24:30028 -> false
 /5.173.249.24:50021 ? /5.173.249.24:30028 -> false
 /5.173.249.24:24282 ? /5.173.249.24:30028 -> false
 /5.173.249.24:24256 ? /5.173.249.24:30028 -> false
```
key is present


error:
```
[23:10:50] [Velocity Async Event Executor - #0/ERROR]: Couldn't pass GameProfileRequestEvent to fastlogin
java.lang.NullPointerException: Cannot invoke "com.github.games647.fastlogin.core.shared.LoginSession.setUuid(java.util.UUID)" because "session" is null
	at com.github.games647.fastlogin.velocity.listener.ConnectListener.onGameprofileRequest(ConnectListener.java:91) ~[?:?]
	at com.github.games647.fastlogin.velocity.listener.Lmbda$30.execute(Unknown Source) ~[?:?]
	at com.velocitypowered.proxy.event.UntargetedEventHandler$VoidHandler.lambda$buildHandler$0(UntargetedEventHandler.java:47) ~[velocity.jar:3.0.2-SNAPSHOT (git-996ada1f-b82)]
	at com.velocitypowered.proxy.event.VelocityEventManager.fire(VelocityEventManager.java:585) ~[velocity.jar:3.0.2-SNAPSHOT (git-996ada1f-b82)]
	at com.velocitypowered.proxy.event.VelocityEventManager.lambda$fire$5(VelocityEventManager.java:466) ~[velocity.jar:3.0.2-SNAPSHOT (git-996ada1f-b82)]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```
```java
LoginSession session = plugin.getSession().get(event.getConnection().getRemoteAddress());
UUID verifiedUUID = event.getGameProfile().getId();
String verifiedUsername = event.getUsername();

session.setUuid(verifiedUUID); <- NPE
```
but get() method doesn't return the object
