### PR TITLE
Added latest Guava and SLF4J compatibility

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -69,6 +69,10 @@
                             <shadedPattern>fastlogin.gson</shadedPattern>
                         </relocation>
                         <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>fastlogin.guava</shadedPattern>
+                        </relocation>
+                        <relocation>
                             <pattern>io.papermc.lib</pattern>
                             <shadedPattern>fastlogin.paperlib</shadedPattern>
                         </relocation>

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -57,6 +57,7 @@
                             <!--Those classes are already present in BungeeCord version-->
                             <exclude>net.md-5:bungeecord-config</exclude>
                             <exclude>com.google.code.gson:gson</exclude>
+                            <exclude>com.google.guava:guava</exclude>
                         </excludes>
                     </artifactSet>
                     <relocations>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,14 +74,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.0-alpha5</version>
         </dependency>
 
         <!-- snakeyaml is present in Bungee, Spigot, Cauldron and so we could use this independent implementation -->
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-config</artifactId>
-            <version>1.12-SNAPSHOT</version>
+            <version>1.16-R0.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -117,14 +117,26 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>17.0</version>
+            <version>31.0.1-jre</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.4</version>
+            <version>2.8.9</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.0-alpha5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.0-alpha5</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -113,12 +113,35 @@
             <version>0.4</version>
         </dependency>
 
-        <!-- APIs we can use because they are available in all platforms (Spigot, Bungee) -->
+        <!-- APIs we can use because they are available in all platforms (Spigot, Bungee, Velocity) -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
-            <scope>provided</scope>
+            <!-- Old version for velocity -->
+            <version>25.1-jre</version>
+            <!-- Exclude compile time deps not marked as such on upstream  -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/core/src/main/java/com/github/games647/fastlogin/core/CommonUtil.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/CommonUtil.java
@@ -35,7 +35,7 @@ import java.util.logging.Level;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.impl.JDK14LoggerAdapter;
+import org.slf4j.jul.JDK14LoggerAdapter;
 
 public class CommonUtil {
 

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FastLoginCore.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FastLoginCore.java
@@ -126,7 +126,7 @@ public class FastLoginCore<P extends C, C, T extends PlatformPlugin<C>> {
         Set<Proxy> proxies = config.getStringList("proxies")
                 .stream()
                 .map(HostAndPort::fromString)
-                .map(proxy -> new InetSocketAddress(proxy.getHostText(), proxy.getPort()))
+                .map(proxy -> new InetSocketAddress(proxy.getHost(), proxy.getPort()))
                 .map(sa -> new Proxy(Type.HTTP, sa))
                 .collect(toSet());
 

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/LoginSession.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/LoginSession.java
@@ -26,6 +26,7 @@
 package com.github.games647.fastlogin.core.shared;
 
 import com.github.games647.fastlogin.core.StoredProfile;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 import java.util.UUID;
@@ -91,7 +92,7 @@ public abstract class LoginSession {
 
     @Override
     public synchronized String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("profile", profile)
                 .add("requestUsername", requestUsername)
                 .add("username", username)

--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -85,6 +85,8 @@
                         <excludes>
                             <exclude>org.slf4j:*</exclude>
                             <exclude>com.google.code.gson:gson</exclude>
+                            <!-- Ships the same old version -->
+                            <exclude>com.google.guava:guava</exclude>
                         </excludes>
                     </artifactSet>
                 </configuration>


### PR DESCRIPTION
(1.18+ breaks support to older guava methods)

### Related issue
java.lang.NoSuchMethodError: 'java.lang.String com.google.common.net.HostAndPort.getHostText()'
	at com.github.games647.fastlogin.core.shared.FastLoginCore.lambda$load$2(FastLoginCore.java:129) ~[?:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at com.github.games647.fastlogin.core.shared.FastLoginCore.load(FastLoginCore.java:131) ~[?:?]
	at com.github.games647.fastlogin.bungee.FastLoginBungee.onEnable(FastLoginBungee.java:88) ~[?:?]
	at net.md_5.bungee.api.plugin.PluginManager.enablePlugins(PluginManager.java:315) ~[Waterfall-1.18-461.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:3e0a6ae:461]
	at net.md_5.bungee.BungeeCord.start(BungeeCord.java:290) ~[Waterfall-1.18-461.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:3e0a6ae:461]
	at net.md_5.bungee.BungeeCordLauncher.main(BungeeCordLauncher.java:67) ~[Waterfall-1.18-461.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:3e0a6ae:461]
	at net.md_5.bungee.Bootstrap.main(Bootstrap.java:15) ~[Waterfall-1.18-461.jar:git:Waterfall-Bootstrap:1.18-R0.1-SNAPSHOT:3e0a6ae:461]
