### PR TITLE
Update to Geyser 2.0 API (fix 1.18)

### DIFF
--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -216,7 +216,7 @@
         <!-- Bedrock player bridge -->
         <dependency>
             <groupId>org.geysermc</groupId>
-            <artifactId>connector</artifactId>
+            <artifactId>core</artifactId>
             <version>${geyser.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -225,6 +225,14 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- We need the API, but it was excluded above -->
+        <dependency>
+            <groupId>org.geysermc</groupId>
+            <artifactId>geyser-api</artifactId>
+            <version>${geyser.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!--Provide premium placeholders-->

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
@@ -55,8 +55,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.geysermc.connector.GeyserConnector;
 import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.geyser.GeyserImpl;
 import org.slf4j.Logger;
 
 /**
@@ -151,7 +151,7 @@ public class FastLoginBukkit extends JavaPlugin implements PlatformPlugin<Comman
 
     private boolean initializeFloodgate() {
         if (getServer().getPluginManager().getPlugin("Geyser-Spigot") != null) {
-            geyserService = new GeyserService(GeyserConnector.getInstance(), core);
+            geyserService = new GeyserService(GeyserImpl.getInstance(), core);
         }
 
         if (getServer().getPluginManager().getPlugin("floodgate") != null) {

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -152,7 +152,7 @@
         <!-- Bedrock player bridge -->
         <dependency>
             <groupId>org.geysermc</groupId>
-            <artifactId>connector</artifactId>
+            <artifactId>core</artifactId>
             <version>${geyser.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -161,6 +161,14 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- We need the API, but it was excluded above -->
+        <dependency>
+            <groupId>org.geysermc</groupId>
+            <artifactId>geyser-api</artifactId>
+            <version>${geyser.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!--Login plugin-->

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/FastLoginBungee.java
@@ -62,8 +62,8 @@ import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import net.md_5.bungee.api.scheduler.GroupedThreadFactory;
 
-import org.geysermc.connector.GeyserConnector;
 import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.geyser.GeyserImpl;
 import org.slf4j.Logger;
 
 /**
@@ -95,7 +95,7 @@ public class FastLoginBungee extends Plugin implements PlatformPlugin<CommandSen
         }
 
         if (isPluginInstalled("Geyser-BungeeCord")) {
-            geyserService = new GeyserService(GeyserConnector.getInstance(), core);
+            geyserService = new GeyserService(GeyserImpl.getInstance(), core);
         }
 
         //events

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -119,7 +119,7 @@
         <!-- Bedrock player bridge -->
         <dependency>
             <groupId>org.geysermc</groupId>
-            <artifactId>connector</artifactId>
+            <artifactId>core</artifactId>
             <version>${geyser.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -128,6 +128,14 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- We need the API, but it was excluded above -->
+        <dependency>
+            <groupId>org.geysermc</groupId>
+            <artifactId>geyser-api</artifactId>
+            <version>${geyser.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!--Common component for contacting the Mojang API-->

--- a/core/src/main/java/com/github/games647/fastlogin/core/hooks/bedrock/GeyserService.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/hooks/bedrock/GeyserService.java
@@ -30,21 +30,21 @@ import java.util.UUID;
 import com.github.games647.fastlogin.core.shared.FastLoginCore;
 import com.github.games647.fastlogin.core.shared.LoginSource;
 
-import org.geysermc.connector.GeyserConnector;
-import org.geysermc.connector.common.AuthType;
-import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.geyser.GeyserImpl;
+import org.geysermc.geyser.session.GeyserSession;
+import org.geysermc.geyser.session.auth.AuthType;
 
 public class GeyserService extends BedrockService<GeyserSession> {
 
-    private final GeyserConnector geyser;
+    private final GeyserImpl geyser;
     private final FastLoginCore<?, ?, ?> core;
     private final AuthType authType;
 
-    public GeyserService(GeyserConnector geyser, FastLoginCore<?, ?, ?> core) {
+    public GeyserService(GeyserImpl geyser, FastLoginCore<?, ?, ?> core) {
         super(core);
         this.geyser = geyser;
         this.core = core;
-        this.authType = geyser.getConfig().getRemote().getAuthType();
+        this.authType = GeyserImpl.getInstance().getConfig().getRemote().getAuthType();
     }
 
     @Override
@@ -65,17 +65,11 @@ public class GeyserService extends BedrockService<GeyserSession> {
 
     @Override
     public GeyserSession getBedrockPlayer(String username) {
-        for (GeyserSession gSess : geyser.getSessionManager().getSessions().values()) {
-            if (gSess.getName().equals(username)) {
-                return gSess;
-            }
-        }
-
-        return null;
+        return geyser.connectionByName(username);
     }
 
     @Override
     public GeyserSession getBedrockPlayer(UUID uuid) {
-        return geyser.getPlayerByUuid(uuid);
+        return geyser.connectionByUuid(uuid);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <floodgate.version>2.0-SNAPSHOT</floodgate.version>
-        <geyser.version>1.4.3-SNAPSHOT</geyser.version>
+        <geyser.version>2.0.0-SNAPSHOT</geyser.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
### Summary of your change
Update to the Geyser 2.0 API.
It's not documented yet, but it's mentioned [here](https://github.com/GeyserMC/Geyser/wiki/Using-Geyser-or-Floodgate-as-a-dependency/_compare/7110301b7486b068eb685c4e4220b05cd18d80f5).

I have only done two test on this:
- I was able to auto log in with Floodgate
- The server starts without Geyser/Floodgate (and premium Java players can auto login)

### Related issue
Fixes https://github.com/games647/FastLogin/issues/672
