### PR TITLE
Differentiate Floodgate players in database

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -220,6 +220,14 @@
       <property name="optional" value="true"/>
     </module>
 
+    <!-- Suppress filters via comments -->
+    <!-- https://stackoverflow.com/a/4023351/9767089 -->
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+      <property name="checkFormat" value="$1"/>
+    </module>
+
   </module>
 
 </module>

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
@@ -82,7 +82,19 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
         profile = core.getStorage().loadProfile(username);
 
         if (profile.isSaved()) {
-            if (!profile.isFloodgateMigrated()) {
+            if (profile.isFloodgateMigrated()) {
+                if (profile.getFloodgate() == FloodgateState.TRUE && isLinked) {
+                    core.getPlugin().getLog()
+                            .info("Player {} is already stored by FastLogin as a non-linked Bedrock Edition player",
+                                    username);
+                    return;
+                } else if (profile.getFloodgate() == FloodgateState.FALSE && isLinked) {
+                    profile.setFloodgate(FloodgateState.LINKED);
+                    core.getPlugin().getLog().info(
+                            "Player {} will be changed from a Java player to a linked Floodgate player",
+                            username);
+                }
+            } else {
                 if (isLinked) {
                     profile.setFloodgate(FloodgateState.LINKED);
                     core.getPlugin().getLog().info(
@@ -93,16 +105,6 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
                     core.getPlugin().getLog().info(
                             "Player {} will be migrated to the v2 database schema as a Floodgate user", username);
                 }
-            } else if (profile.getFloodgate() == FloodgateState.TRUE && isLinked) {
-                core.getPlugin().getLog()
-                        .info("Player {} is already stored by FastLogin as a non-linked Bedrock Edition player",
-                                username);
-                return;
-            } else if (profile.getFloodgate() == FloodgateState.FALSE && isLinked) {
-                profile.setFloodgate(FloodgateState.LINKED);
-                core.getPlugin().getLog().info(
-                        "Player {} will be changed from a Java player to a linked Floodgate player",
-                        username);
             }
         } else {
             if (isLinked) {

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateState.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateState.java
@@ -26,9 +26,25 @@
 package com.github.games647.fastlogin.core.shared;
 
 public enum FloodgateState {
+
+    /**
+     * Purely Java profile
+     */
     FALSE(0),
+
+    /**
+     * Purely Bedrock profile
+     */
     TRUE(1),
+
+    /**
+     * Bedrock profile is bidirectional associated with the Java Mojang profile.
+     */
     LINKED(2),
+
+    /**
+     * Data before floodgate database migration. Floodgate state is unknown.
+     */
     NOT_MIGRATED(3);
 
     private int value;

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateState.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateState.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2022 games647 and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.games647.fastlogin.core.shared;
+
+public enum FloodgateState {
+    FALSE(0),
+    TRUE(1),
+    LINKED(2),
+    NOT_MIGRATED(3);
+
+    private int value;
+
+    FloodgateState(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Convert a number to FloodgateState
+     * <ol start="0">
+     *     <li>False</li>
+     *     <li>True</li>
+     *     <li>Linked</li>
+     *     <li>Not Migrated</li>
+     * </ol>
+     * @param num the number, most likely loaded from the database
+     * @return FloodgateStatus on success, null otherwise
+     */
+    public static FloodgateState fromInt(int num) {
+        // using Enum.values()[i] is expensive as per https://stackoverflow.com/a/8762387/9767089
+        switch (num) {
+            case 0:
+                return FloodgateState.FALSE;
+            case 1:
+                return FloodgateState.TRUE;
+            case 2:
+                return FloodgateState.LINKED;
+            case 3:
+                return FloodgateState.NOT_MIGRATED;
+            default:
+                return null;
+        }
+    }
+}

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateState.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateState.java
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2015-2022 games647 and contributors
+ * Copyright (c) 2015-2023 games647 and contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/core/src/main/java/com/github/games647/fastlogin/core/storage/SQLStorage.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/storage/SQLStorage.java
@@ -26,7 +26,6 @@
 package com.github.games647.fastlogin.core.storage;
 
 import com.github.games647.craftapi.UUIDAdapter;
-import com.github.games647.fastlogin.core.StoredProfile;
 import com.github.games647.fastlogin.core.shared.FloodgateState;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;

--- a/core/src/main/java/com/github/games647/fastlogin/core/storage/SQLiteStorage.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/storage/SQLiteStorage.java
@@ -31,14 +31,22 @@ import org.sqlite.JDBC;
 import org.sqlite.SQLiteConfig;
 
 import java.nio.file.Path;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class SQLiteStorage extends SQLStorage {
+
+    protected static final String CREATE_TABLE_STMT = "CREATE TABLE IF NOT EXISTS `" + PREMIUM_TABLE + "` ("
+            + "`UserID` INTEGER PRIMARY KEY AUTO_INCREMENT, "
+            + "`UUID` CHAR(36), "
+            + "`Name` VARCHAR(16) NOT NULL, "
+            + "`Premium` BOOLEAN NOT NULL, "
+            + "`LastIp` VARCHAR(255) NOT NULL, "
+            + "`LastLogin` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
+            //the premium shouldn't steal the cracked account by changing the name
+            + "UNIQUE (`Name`) "
+            + ')';
 
     private static final String SQLITE_DRIVER = "org.sqlite.SQLiteDataSource";
     private final Lock lock = new ReentrantLock();
@@ -103,12 +111,9 @@ public class SQLiteStorage extends SQLStorage {
     }
 
     @Override
-    public void createTables() throws SQLException {
-        try (Connection con = dataSource.getConnection();
-             Statement createStmt = con.createStatement()) {
-            // SQLite has a different syntax for auto increment
-            createStmt.executeUpdate(CREATE_TABLE_STMT.replace("AUTO_INCREMENT", "AUTOINCREMENT"));
-        }
+    protected String getCreateTableStmt() {
+        // SQLite has a different syntax for auto increment
+        return CREATE_TABLE_STMT.replace("AUTO_INCREMENT", "AUTOINCREMENT");
     }
 
     private static String replacePathVariables(Path dataFolder, String input) {

--- a/core/src/main/java/com/github/games647/fastlogin/core/storage/StoredProfile.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/storage/StoredProfile.java
@@ -26,6 +26,7 @@
 package com.github.games647.fastlogin.core.storage;
 
 import com.github.games647.craftapi.model.Profile;
+import com.github.games647.fastlogin.core.shared.FloodgateState;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -39,20 +40,28 @@ public class StoredProfile extends Profile {
     private final ReentrantLock saveLock = new ReentrantLock();
 
     private boolean premium;
+    private FloodgateState floodgate;
     private String lastIp;
     private Instant lastLogin;
 
-    public StoredProfile(long rowId, UUID uuid, String playerName, boolean premium, String lastIp, Instant lastLogin) {
+    public StoredProfile(long rowId, UUID uuid, String playerName, boolean premium, FloodgateState floodgate,
+                         String lastIp, Instant lastLogin) {
         super(uuid, playerName);
 
         this.rowId = rowId;
         this.premium = premium;
+        this.floodgate = floodgate;
         this.lastIp = lastIp;
         this.lastLogin = lastLogin;
     }
 
+    public StoredProfile(UUID uuid, String playerName, boolean premium, FloodgateState isFloodgate, String lastIp) {
+        this(-1, uuid, playerName, premium, isFloodgate, lastIp, Instant.now());
+    }
+
+    @Deprecated
     public StoredProfile(UUID uuid, String playerName, boolean premium, String lastIp) {
-        this(-1, uuid, playerName, premium, lastIp, Instant.now());
+        this(-1, uuid, playerName, premium, FloodgateState.FALSE, lastIp, Instant.now());
     }
 
     public ReentrantLock getSaveLock() {
@@ -96,6 +105,18 @@ public class StoredProfile extends Profile {
         this.premium = premium;
     }
 
+    public synchronized FloodgateState getFloodgate() {
+        return floodgate;
+    }
+
+    public synchronized boolean isFloodgateMigrated() {
+        return floodgate != FloodgateState.NOT_MIGRATED;
+    }
+
+    public synchronized void setFloodgate(FloodgateState floodgate) {
+        this.floodgate = floodgate;
+    }
+
     public synchronized String getLastIp() {
         return lastIp;
     }
@@ -128,7 +149,7 @@ public class StoredProfile extends Profile {
         }
 
         return rowId == that.rowId && premium == that.premium
-            && Objects.equals(lastIp, that.lastIp) && lastLogin.equals(that.lastLogin);
+                && Objects.equals(lastIp, that.lastIp) && lastLogin.equals(that.lastLogin);
     }
 
     @Override
@@ -141,6 +162,7 @@ public class StoredProfile extends Profile {
         return this.getClass().getSimpleName() + '{'
             + "rowId=" + rowId
             + ", premium=" + premium
+            + ", floodgate=" + floodgate
             + ", lastIp='" + lastIp + '\''
             + ", lastLogin=" + lastLogin
             + "} " + super.toString();


### PR DESCRIPTION
### Summary of your change
Please read #700.
Added a new column to the database called `Floodgate`.
This will make the life of Bedrock and Java players with the same name a lot easier.

### Why Draft
I've just started working on this, and I wanted to share the code while I'm progressing with it.
***<ins>At this stage you have to delete the old database, or the server will crash when someone tries to join it.</ins>***

### Todo
- [x] Database migrator (so the old database won't have to be deleted)
- [x] Migrate every part of the code to be aware of the new `Floodgate` field in the database
  - [x] ~~Migrate `activate` plugin message~~*
  - [x] ~~Migrate `/cracked` and `/premium` commands (self)~~*
    - [x] Fix issue described at "Floodgate detection" (issue #689)
  - [x] ~~Migrate `/cracked` and `/premium` commands (others)~~*
- [x] Check what the `Premium` field in the db does for Floodgate players (so check for leftover code)
- [ ] Debug why `uuid` and `lastIp` are `null` for Floodgate players in the database ([code](https://github.com/games647/FastLogin/blob/8a01ddc231d6981be4ed755d3669727fc3bed4f5/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java#L171-L172))

_*No longer needed, becuase usernames are now unique (https://github.com/games647/FastLogin/pull/709#issuecomment-1184623441)._

### To Test
*just notes for myself, so that I won't forget it*
- [x] Server without Floodgate
- [x] BungeeCord
- [x] Premium/Cracked commands
- [x] [AsyncToggleMessage](https://github.com/games647/FastLogin/blob/9656aadb353b0061b40f405cecab3481cd422738/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/AsyncToggleMessage.java)
- [x] Auto login/register with same name Java and Bedrock accounts
    Result: only works on the platform where premium login was enabled

### Floodgate detection
https://github.com/games647/FastLogin/issues/689 needs to be fixed. (I'm not linking that issue to his PR on purpose, as it's not fixed yet.)
In short, if ProtocolLib prefix workaround is enabled, the following code wont work, after the prefix is added:
https://github.com/games647/FastLogin/blob/9b04ea5c89e0b99bc273d28a1d9b0483c0a1b903/core/src/main/java/com/github/games647/fastlogin/core/hooks/bedrock/FloodgateService.java#L105-L114

### Related issue
Fixes https://github.com/games647/FastLogin/issues/700 
Fixes https://github.com/games647/FastLogin/issues/696
Fixes https://github.com/games647/FastLogin/issues/633
