### PR TITLE
Fix plugin start without ProtocolLib installed

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
@@ -25,7 +25,6 @@
  */
 package com.github.games647.fastlogin.bukkit;
 
-import com.comphenix.protocol.ProtocolLibrary;
 import com.github.games647.fastlogin.bukkit.command.CrackedCommand;
 import com.github.games647.fastlogin.bukkit.command.PremiumCommand;
 import com.github.games647.fastlogin.bukkit.listener.ConnectionListener;
@@ -121,7 +120,7 @@ public class FastLoginBukkit extends JavaPlugin implements PlatformPlugin<Comman
 
                 if (isPluginInstalled("floodgate")) {
                     if (getConfig().getBoolean("floodgatePrefixWorkaround")){
-                        ProtocolLibrary.getProtocolManager().addPacketListener(new ManualNameChange(this, floodgateService));
+                        ManualNameChange.register(this, floodgateService);
                         logger.info("Floodgate prefix injection workaround has been enabled.");
                         logger.info("If you have problems joining the server, try disabling it in the configuration.");
                     } else {

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ManualNameChange.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ManualNameChange.java
@@ -36,6 +36,8 @@ import org.geysermc.floodgate.api.FloodgateApi;
 
 import static com.comphenix.protocol.PacketType.Login.Client.START;
 
+import com.comphenix.protocol.ProtocolLibrary;
+
 /**
  * Manually inject Floodgate player name prefixes.
  * <br>
@@ -55,6 +57,14 @@ public class ManualNameChange extends PacketAdapter {
 
         this.plugin = plugin;
         this.floodgate = floodgate;
+    }
+
+    public static void register(FastLoginBukkit plugin, FloodgateService floodgate) {
+        // they will be created with a static builder, because otherwise it will throw a NoClassDefFoundError
+        ProtocolLibrary.getProtocolManager()
+                .getAsynchronousManager()
+                .registerAsyncHandler(new ManualNameChange(plugin, floodgate))
+                .start();
     }
 
     @Override


### PR DESCRIPTION
### Summary of your change

Referencing `ProtocolLibrary` in FastLoginBukkit (even in an unreachable code block) causes Bukkit servers to throw a NoClassDefFoundError on startup.
Fix based on commit 0082cc65368a13c51a33a0c54801d6c65eb289a9

### Related issue

I have absolutely zero idea how no one has reported that FastLoginBukkit can not be started without ProtocolLib for [over a month](https://ci.codemc.io/job/Games647/job/FastLogin/1039/). Anyways, I'm not going to open a new issue just to close it here.