### PR TITLE
Fix 'no-conflict' option of 'autoLoginFloodgate' in config

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
@@ -49,7 +49,7 @@ public class FloodgateAuthTask extends FloodgateManagement<Player, CommandSender
         BukkitLoginSession session = new BukkitLoginSession(player.getName(), isRegistered, profile);
 
         // enable auto login based on the value of 'autoLoginFloodgate' in config.yml
-        session.setVerified(isAutoLoginAllowed());
+        session.setVerified(isAutoAuthAllowed(autoLoginFloodgate));
 
         // run login task
         Runnable forceLoginTask = new ForceLoginTask(core.getPlugin().getCore(), player, session);

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/task/FloodgateAuthTask.java
@@ -49,8 +49,7 @@ public class FloodgateAuthTask extends FloodgateManagement<Player, CommandSender
         BukkitLoginSession session = new BukkitLoginSession(player.getName(), isRegistered, profile);
 
         // enable auto login based on the value of 'autoLoginFloodgate' in config.yml
-        session.setVerified(autoLoginFloodgate.equals("true")
-                || (autoLoginFloodgate.equals("linked") && isLinked));
+        session.setVerified(isAutoLoginAllowed());
 
         // run login task
         Runnable forceLoginTask = new ForceLoginTask(core.getPlugin().getCore(), player, session);

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/FloodgateAuthTask.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/FloodgateAuthTask.java
@@ -55,13 +55,9 @@ public class FloodgateAuthTask
         BungeeLoginSession session = new BungeeLoginSession(player.getName(), isRegistered, profile);
         core.getPlugin().getSession().put(player.getPendingConnection(), session);
 
-        // enable auto login based on the value of 'autoLoginFloodgate' in config.yml
-        boolean forcedOnlineMode = autoLoginFloodgate.equals("true")
-                || (autoLoginFloodgate.equals("linked") && isLinked);
-
         // run login task
         Runnable forceLoginTask = new ForceLoginTask(core.getPlugin().getCore(), player, server, session,
-                forcedOnlineMode);
+                isAutoLoginAllowed());
         core.getPlugin().getScheduler().runAsync(forceLoginTask);
     }
 

--- a/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/FloodgateAuthTask.java
+++ b/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/FloodgateAuthTask.java
@@ -57,7 +57,7 @@ public class FloodgateAuthTask
 
         // run login task
         Runnable forceLoginTask = new ForceLoginTask(core.getPlugin().getCore(), player, server, session,
-                isAutoLoginAllowed());
+                isAutoAuthAllowed(autoLoginFloodgate));
         core.getPlugin().getScheduler().runAsync(forceLoginTask);
     }
 

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
@@ -146,6 +146,17 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
     }
 
     /**
+     * Decide if the player can be auto logged in.
+     * The config option 'non-conflicting' is ignored by this function.
+     * @return true if the Player can be logged in automatically
+     */
+    protected boolean isAutoLoginAllowed() {
+        return "true".equals(autoLoginFloodgate)
+            || "no-conflict".equals(autoRegisterFloodgate) // this was checked before
+            || ("linked".equals(autoLoginFloodgate) && isLinked);
+    }
+
+    /**
      * Decides wether checks for conflicting Java names should be made
      * @return ture if an API call to Mojang is needed
      */

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
@@ -120,7 +120,7 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
             }
         }
 
-        if (!isRegistered && !isAutoRegisterAllowed()) {
+        if (!isRegistered && !isAutoAuthAllowed(autoRegisterFloodgate)) {
             return;
         }
 
@@ -135,25 +135,18 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
     }
 
     /**
-     * Decude if the player can be auto registered.
-     * The config option 'non-conflicting' is ignored by this function.
+     * Decide if the player can be automatically registered or logged in.<br>
+     * The config option 'non-conflicting' is ignored by this function, as name
+     * conflicts are checked by a different part of the code.
+     * 
+     * @param configValue the value of either 'autoLoginFloodgate' or
+     *                    'autoRegisterFloodgate' from config.yml
      * @return true if the Player can be registered automatically
      */
-    private boolean isAutoRegisterAllowed() {
-        return "true".equals(autoRegisterFloodgate)
-                || "no-conflict".equals(autoRegisterFloodgate) // this was checked before
-                || ("linked".equals(autoRegisterFloodgate) && isLinked);
-    }
-
-    /**
-     * Decide if the player can be auto logged in.
-     * The config option 'non-conflicting' is ignored by this function.
-     * @return true if the Player can be logged in automatically
-     */
-    protected boolean isAutoLoginAllowed() {
-        return "true".equals(autoLoginFloodgate)
-            || "no-conflict".equals(autoRegisterFloodgate) // this was checked before
-            || ("linked".equals(autoLoginFloodgate) && isLinked);
+    protected boolean isAutoAuthAllowed(String configValue) {
+        return "true".equals(configValue)
+                || "no-conflict".equals(configValue) // this was checked before
+                || ("linked".equals(configValue) && isLinked);
     }
 
     /**


### PR DESCRIPTION
### Summary of your change
Added checks for missing `no-conflict` checks to this code for both Bukkit & Bungee

https://github.com/games647/FastLogin/blob/4c514c269b46bb6d28b9e34e6eecb3448eefdedd/bungee/src/main/java/com/github/games647/fastlogin/bungee/task/FloodgateAuthTask.java#L58-L60

Instead of simply adding the missing two lines, I've done a bit of a code clean up. I've merged the checks of the code mentioned above and `isAutoRegisterAllowed()` into a common function. I've made 2 commits, to make it easier to understand what I did and why.

### Related issue
Fixes https://github.com/games647/FastLogin/issues/736
