### PR TITLE
Support for transparent proxies / DNAT

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/VerifyResponseTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/VerifyResponseTask.java
@@ -36,15 +36,18 @@ import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedGameProfile;
 import com.github.games647.craftapi.model.auth.Verification;
 import com.github.games647.craftapi.model.skin.SkinProperty;
+import com.github.games647.craftapi.resolver.AbstractResolver;
 import com.github.games647.craftapi.resolver.MojangResolver;
 import com.github.games647.fastlogin.bukkit.BukkitLoginSession;
 import com.github.games647.fastlogin.bukkit.FastLoginBukkit;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
+import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyPair;
@@ -138,7 +141,10 @@ public class VerifyResponseTask implements Runnable {
         try {
             MojangResolver resolver = plugin.getCore().getResolver();
             InetAddress address = socketAddress.getAddress();
-            Optional<Verification> response = resolver.hasJoined(requestedUsername, serverId, address);
+
+            // TODO edit marker
+            Optional<Verification> response = VerifyResponseTask.hasJoined(resolver, requestedUsername, serverId, address);
+
             if (response.isPresent()) {
                 Verification verification = response.get();
                 plugin.getLog().info("Profile {} has a verified premium account", requestedUsername);
@@ -162,12 +168,89 @@ public class VerifyResponseTask implements Runnable {
             } else {
                 //user tried to fake an authentication
                 disconnect("invalid-session",
-                    "GameProfile {0} ({1}) tried to log in with an invalid session ServerId: {2}",
-                    session.getRequestUsername(), socketAddress, serverId);
+                    String.format("GameProfile %s (%s) tried to log in with an invalid session. ServerId: %s",
+                    session.getRequestUsername(), socketAddress, serverId));
             }
         } catch (IOException ioEx) {
             disconnect("error-kick", "Failed to connect to session server", ioEx);
         }
+    }
+
+    /**
+     * A reimplementation of {@link MojangResolver#hasJoined(String, String, InetAddress)} using various crude reflection-based hacks
+     * to access the protected code. The significant difference is that unlike in the CraftAPI implementation, which sends the "ip" parameter
+     * when the hostIp parameter is an IPv4 address, but skips it for IPv6, this implementation ommits the "ip" parameter also for IPv4, effectively
+     * enabling transparent proxies to work.
+     *
+     * TODO Reimplement as MojangResolver subclass overriding hasJoined method -> "ProxyAgnosticMojangResolver" perhaps?
+     *
+     * @param resolver The mojang resolver object the method will operate on
+     * @param username The literal username of the player
+     * @param serverHash The computed server hash sent to mojang session servers
+     * @param hostIp The host IP address - not used, kept to maintain similar signature
+     * @return An optional object containing the verification information, if any. If there is no verification information, the session servers consider the join invalid.
+     * @throws IOException When an error occurs during the HTTP communication
+     * @author games647, Enginecrafter77
+     */
+    public static Optional<Verification> hasJoined(MojangResolver resolver, String username, String serverHash, InetAddress hostIp) throws IOException {
+        /*String url;
+        if (hostIp instanceof Inet6Address) {
+            url = String.format("https://sessionserver.mojang.com/session/minecraft/hasJoined?username=%s&serverId=%s", username, serverHash);
+        } else {
+            String encodedIP = URLEncoder.encode(hostIp.getHostAddress(), StandardCharsets.UTF_8.name());
+            url = String.format("https://sessionserver.mojang.com/session/minecraft/hasJoined?username=%s&serverId=%s&ip=%s", username, serverHash, encodedIP);
+        }*/
+        String url = String.format("https://sessionserver.mojang.com/session/minecraft/hasJoined?username=%s&serverId=%s", username, serverHash);
+
+        try
+        {
+            Class<?> inputStreamActionClass = Class.forName("com.github.games647.craftapi.resolver.AbstractResolver$InputStreamAction");
+            Method getConnectionMethod = AbstractResolver.class.getDeclaredMethod("getConnection", String.class);
+            Method parseRequestMethod = AbstractResolver.class.getDeclaredMethod("parseRequest", HttpURLConnection.class, inputStreamActionClass);
+            Method readJsonMethod = AbstractResolver.class.getDeclaredMethod("readJson", InputStream.class, Class.class);
+
+            getConnectionMethod.setAccessible(true);
+            parseRequestMethod.setAccessible(true);
+            readJsonMethod.setAccessible(true);
+
+            HttpURLConnection conn = (HttpURLConnection)getConnectionMethod.invoke(resolver, url);
+            int responseCode = conn.getResponseCode();
+
+            Verification result = null;
+            if(responseCode != 204)
+            {
+                AbstractResolverAdapter.InputStreamActionAdapter<Verification> action = new AbstractResolverAdapter.InputStreamActionAdapter<Verification>() {
+                    @Override
+                    public Verification useStream(InputStream inp) throws IOException
+                    {
+                        try
+                        {
+                            return (Verification)readJsonMethod.invoke(resolver, new Object[] {inp, Verification.class});
+                        }
+                        catch(ReflectiveOperationException exc)
+                        {
+                            throw new IOException("Reflective method access failed", exc);
+                        }
+                    }
+                };
+                result = (Verification)parseRequestMethod.invoke(resolver, new Object[] {conn, action});
+            }
+            return Optional.ofNullable(result);
+        }
+        catch(ReflectiveOperationException exc)
+        {
+            throw new RuntimeException("Error occured in reflective hacks to MojangResolver", exc);
+        }
+    }
+
+    /**
+     * An adapter class used to make the InputStreamAction interface accessible to us.
+     * I know, it's a crude and disgusting solution, but bear with me, it's just temporary.
+     */
+    public static class AbstractResolverAdapter extends AbstractResolver
+    {
+        @FunctionalInterface
+        protected static interface InputStreamActionAdapter<R> extends AbstractResolver.InputStreamAction<R> {}
     }
 
     private void setPremiumUUID(UUID premiumUUID) {

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/VerifyResponseTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/VerifyResponseTask.java
@@ -164,9 +164,7 @@ public class VerifyResponseTask implements Runnable {
                 receiveFakeStartPacket(realUsername);
             } else {
                 //user tried to fake an authentication
-                disconnect("invalid-session",
-                    String.format("GameProfile %s (%s) tried to log in with an invalid session. ServerId: %s",
-                    session.getRequestUsername(), socketAddress, serverId));
+                disconnect("invalid-session", "GameProfile {} ({}) tried to log in with an invalid session. ServerId: {}", session.getRequestUsername(), socketAddress, serverId);
             }
         } catch (IOException ioEx) {
             disconnect("error-kick", "Failed to connect to session server", ioEx);

--- a/core/src/main/java/com/github/games647/fastlogin/core/mojang/ProxyAgnosticMojangResolver.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/mojang/ProxyAgnosticMojangResolver.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015-2022 games647 and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.github.games647.fastlogin.core.mojang;
+
+import com.github.games647.craftapi.model.auth.Verification;
+import com.github.games647.craftapi.resolver.MojangResolver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.util.Optional;
+
+/**
+ * An extension to {@link MojangResolver} which allows connection using transparent reverse proxies.
+ * The significant difference is that unlike MojangResolver from the CraftAPI implementation, which sends the "ip" parameter
+ * when the hostIp parameter is an IPv4 address, but skips it for IPv6, this implementation leaves out the "ip" parameter
+ * also for IPv4, effectively enabling transparent proxies to work.
+ * @author games647, Enginecrafter77
+ */
+public class ProxyAgnosticMojangResolver extends MojangResolver {
+	@Override
+	public Optional<Verification> hasJoined(String username, String serverHash, InetAddress hostIp) throws IOException
+	{
+		String url = String.format("https://sessionserver.mojang.com/session/minecraft/hasJoined?username=%s&serverId=%s", username, serverHash);
+
+		HttpURLConnection conn = this.getConnection(url);
+		int responseCode = conn.getResponseCode();
+
+		Verification verification = null;
+		if(responseCode != 204)
+			verification = this.parseRequest(conn, this::parseVerification);
+		return Optional.ofNullable(verification);
+	}
+
+	// Functional implementation of InputStreamAction
+	protected Verification parseVerification(InputStream input) throws IOException
+	{
+		return this.readJson(input, Verification.class);
+	}
+}

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FastLoginCore.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FastLoginCore.java
@@ -33,6 +33,7 @@ import com.github.games647.fastlogin.core.TickingRateLimiter;
 import com.github.games647.fastlogin.core.hooks.AuthPlugin;
 import com.github.games647.fastlogin.core.hooks.DefaultPasswordGenerator;
 import com.github.games647.fastlogin.core.hooks.PasswordGenerator;
+import com.github.games647.fastlogin.core.mojang.ProxyAgnosticMojangResolver;
 import com.github.games647.fastlogin.core.storage.MySQLStorage;
 import com.github.games647.fastlogin.core.storage.SQLStorage;
 import com.github.games647.fastlogin.core.storage.SQLiteStorage;
@@ -83,7 +84,8 @@ public class FastLoginCore<P extends C, C, T extends PlatformPlugin<C>> {
     private final Collection<UUID> pendingConfirms = new HashSet<>();
     private final T plugin;
 
-    private final MojangResolver resolver = new MojangResolver();
+    //private final MojangResolver resolver = new MojangResolver();
+    private final MojangResolver resolver = new ProxyAgnosticMojangResolver();
 
     private Configuration config;
     private SQLStorage storage;

--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FastLoginCore.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FastLoginCore.java
@@ -84,8 +84,7 @@ public class FastLoginCore<P extends C, C, T extends PlatformPlugin<C>> {
     private final Collection<UUID> pendingConfirms = new HashSet<>();
     private final T plugin;
 
-    //private final MojangResolver resolver = new MojangResolver();
-    private final MojangResolver resolver = new ProxyAgnosticMojangResolver();
+    private MojangResolver resolver;
 
     private Configuration config;
     private SQLStorage storage;
@@ -119,6 +118,9 @@ public class FastLoginCore<P extends C, C, T extends PlatformPlugin<C>> {
             plugin.getLog().error("Failed to load yaml files", ioEx);
             return;
         }
+
+        // Initialize the resolver based on the config parameter
+        this.resolver = this.config.getBoolean("useProxyAgnosticResolver", false) ? new ProxyAgnosticMojangResolver() : new MojangResolver();
 
         rateLimiter = createRateLimiter(config.getSection("anti-bot"));
         Set<Proxy> proxies = config.getStringList("proxies")

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -159,7 +159,7 @@ premium-warning: true
 # negligible to no security impact.
 #
 # This setting works on a similar principle as 'prevent-proxy' setting in server.properties.
-# When set to false, the server behaves like prevent-proxy was set to false and vice-versa.
+# When set to false, the server behaves like prevent-proxy was set to true and vice-versa.
 # Normally, when you use the prevent-proxy=true, you would want this disabled.
 #
 # Please note that this setting has no effect when used outside of Spigot+ProtocolLib context.

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -152,6 +152,17 @@ forwardSkin: true
 # If they still want to invoke the command, they have to invoke /premium again
 premium-warning: true
 
+# When set to true, enables the use of alternative session resolver which does not send the server IP
+# to mojang session servers. This setting might be useful when you are trying to run the server via a
+# transparent reverse proxy or some other form of DNAT. As far as security goes, this setting has
+# negligible to no security impact.
+#
+# !!! [WARNING] !!!
+# This option is considered highly experimental. While it is highly unlikely this will break your server,
+# more tests need to be conducted in order to verify it's effectiveness. Brief tests seemed promising, but
+# every environment is different, and so it might not work for you as it did for me.
+useProxyAgnosticResolver: false
+
 # If you have autoRegister or nameChangeCheck enabled, you could be rate-limited by Mojang.
 # The requests of the both options will be only made by FastLogin if the username is unknown to the server
 # You are allowed to make 600 requests per 10-minutes (60 per minute)

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -152,14 +152,21 @@ forwardSkin: true
 # If they still want to invoke the command, they have to invoke /premium again
 premium-warning: true
 
+# ======[[ Spigot+ProtocolLib users only ]]======
 # When set to true, enables the use of alternative session resolver which does not send the server IP
 # to mojang session servers. This setting might be useful when you are trying to run the server via a
 # transparent reverse proxy or some other form of DNAT. As far as security goes, this setting has
 # negligible to no security impact.
 #
+# This setting works on a similar principle as 'prevent-proxy' setting in server.properties.
+# When set to false, the server behaves like prevent-proxy was set to false and vice-versa.
+# Normally, when you use the prevent-proxy=true, you would want this disabled.
+#
+# Please note that this setting has no effect when used outside of Spigot+ProtocolLib context.
+#
 # !!! [WARNING] !!!
 # This option is considered highly experimental. While it is highly unlikely this will break your server,
-# more tests need to be conducted in order to verify it's effectiveness. Brief tests seemed promising, but
+# more tests need to be conducted in order to verify its effectiveness. Brief tests seemed promising, but
 # every environment is different, and so it might not work for you as it did for me.
 useProxyAgnosticResolver: false
 


### PR DESCRIPTION
[//]: # (Lines in this format are considered as comments and will not be displayed.)
[//]: # (If your work is in progress, please consider making a draft pull request.)

### Proposed changes
This pull request addresses #810 and other possibly relates cases of servers being hidden behind transparent reverse proxy.

The basic motivation behind this change is this scenario. Imagine you had a minecraft server. You cannot forward ports on your firewall (e.g. a bad ISP). So you opt for an external server which will act as a reverse proxy for your server. The users of your server would connect to the proxy server, which will transparently route the data to your server (e.g. using a VPN or SSH tunnel). 

The problem is that in some cases, FastLogin will not work due to the way it invokes the `hasJoined` method on mojang session servers. The default CraftAPI implementation, along with other data, includes the `ip` parameter in the request. This, however, is a problem since mojang has stored the true IP of the client, while the server sends the IP of the proxy server, and thus the authentication fails with "Invalid Session".

The way this pull request resolves the issue is by leaving out the `ip` parameter altogether. According to [wiki.vg page about the protocol authentication](https://wiki.vg/Protocol_Encryption#Authentication), the `ip` parameter is optional. Leaving out the parameter skips the check which was causing the "Invalid Session", and thus allows players to play on your server using transparent TCP proxies.

Regarding the security concerns of this implementation, the user opting for such measures should already be aware that by using a transparent proxy, all the user IP addresses will be the same, and therefore things like IP bans and/or plugins that rely on unique IP per player might not work as expected. Additionally, since the user is already aware of the fact that the player's IP as seen by the server is not the real IP of the player, they do not need mojang to check the player IP if they already know it is not the real one.

The feature implemented by this pull request is deactivated by default and can be enabled through the FastLogin config file. Older versions of the config file missing the entry will NOT cause problems since the key defaults to false when not present. That means this feature will NOT impact existing users of FastLogin, but will merely enable interested users to turn it on.

### Related issue
[//]: # (Reference it using '#NUMBER'. Ex: Fixes/Related #...)
Fixes #810 and related cases