### PR TITLE
Fix unregister ProtocolLib

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/FastLoginBukkit.java
@@ -187,7 +187,7 @@ public class FastLoginBukkit extends JavaPlugin implements PlatformPlugin<Comman
             }
         }
 
-        if (isPluginInstalled("ProtocolLib")) {
+        if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) {
             ProtocolLibrary.getProtocolManager().getAsynchronousManager().unregisterAsyncHandlers(this);
         }
     }


### PR DESCRIPTION
### Summary of your change

When FastLogin is disabled, the plugin unregisters from ProtocolLib (if ProtocolLib is present in the "plugins" folder). But it doesn't check if ProtocolLib is still loaded and not already disabled.
Accessing ProtocolLib methods when the plugin is disabled creates an error.
I modified the check to see if ProtocolLib is still loaded :

```java
if (isPluginInstalled("ProtocolLib")) { //if ProtocolLib is present in the "plugins" folder
    ProtocolLibrary.getProtocolManager().getAsynchronousManager().unregisterAsyncHandlers(this);
 }
 ```
 To
 ```java
if (getServer().getPluginManager().isPluginEnabled("ProtocolLib")) { //if ProtocolLib is still loaded
    ProtocolLibrary.getProtocolManager().getAsynchronousManager().unregisterAsyncHandlers(this);
 }
 ```

### Related issue

Fixes/Related #885
