### PR TITLE
1.20.2 Fix

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/VerifyResponseTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/VerifyResponseTask.java
@@ -38,6 +38,7 @@ import com.comphenix.protocol.reflect.accessors.FieldAccessor;
 import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.utility.MinecraftVersion;
 import com.comphenix.protocol.wrappers.BukkitConverters;
+import com.comphenix.protocol.wrappers.Converters;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import com.comphenix.protocol.wrappers.WrappedGameProfile;
 import com.comphenix.protocol.wrappers.WrappedProfilePublicKey.WrappedProfileKeyData;
@@ -202,7 +203,7 @@ public class VerifyResponseTask implements Runnable {
         session.setVerified(true);
 
         setPremiumUUID(session.getUuid());
-        receiveFakeStartPacket(realUsername, session.getClientPublicKey());
+        receiveFakeStartPacket(realUsername, session.getClientPublicKey(), session.getUuid());
     }
 
     private void setPremiumUUID(UUID premiumUUID) {
@@ -293,9 +294,13 @@ public class VerifyResponseTask implements Runnable {
     }
 
     //fake a new login packet in order to let the server handle all the other stuff
-    private void receiveFakeStartPacket(String username, ClientPublicKey clientKey) {
+    private void receiveFakeStartPacket(String username, ClientPublicKey clientKey, UUID uuid) {
         PacketContainer startPacket;
-        if (new MinecraftVersion(1, 19, 0).atOrAbove()) {
+        if (new MinecraftVersion(1, 20, 2).atOrAbove()) {
+            startPacket = new PacketContainer(START);
+            startPacket.getStrings().write(0, username);
+            startPacket.getUUIDs().write(0, uuid);
+        } else if (new MinecraftVersion(1, 19, 0).atOrAbove()) {
             startPacket = new PacketContainer(START);
             startPacket.getStrings().write(0, username);
 

--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/VerifyResponseTask.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/VerifyResponseTask.java
@@ -300,6 +300,10 @@ public class VerifyResponseTask implements Runnable {
             startPacket = new PacketContainer(START);
             startPacket.getStrings().write(0, username);
             startPacket.getUUIDs().write(0, uuid);
+        } else if (new MinecraftVersion(1, 19, 3).atOrAbove()) {
+            startPacket = new PacketContainer(START);
+            startPacket.getStrings().write(0, username);
+            startPacket.getOptionals(Converters.passthrough(UUID.class)).write(0, Optional.of(uuid));
         } else if (new MinecraftVersion(1, 19, 0).atOrAbove()) {
             startPacket = new PacketContainer(START);
             startPacket.getStrings().write(0, username);

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.28</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
 
@@ -201,8 +201,8 @@
         <!-- Require inline to support static mocks -->
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>5.2.0</version>
+            <artifactId>mockito-core</artifactId>
+            <version>5.6.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
### Summary of your change
Before fast login had support for two variants of the start login packet - before and after 1.19.
But since then the packet has changed two times:
- In 1.19.3 removing all the signing and cryptographic stuff from it. Somehow it didn't break FastLogin, but it's always better to have it implemented properly.
- In 1.20.2 the player's uuid stopped being optional field. This broke FastLogin, resulting in an error as reported in #1095

While figuring out what broke I accidentally found out that 1.19.3+ should have a proper implementation so I added it too.
Here is an image on how the start login packet has changed since 1.18.2.
![loginpacket](https://github.com/games647/FastLogin/assets/67533827/cfff9143-471b-4e91-a2bd-1f545f7b2cc0)
### Related issue
Fixes #1095