### PR TITLE
Fix floodgate config parsing

### DIFF
--- a/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
+++ b/core/src/main/java/com/github/games647/fastlogin/core/shared/FloodgateManagement.java
@@ -62,9 +62,9 @@ public abstract class FloodgateManagement<P extends C, C, L extends LoginSession
         this.username = getName(player);
 
         //load values from config.yml
-        autoLoginFloodgate = core.getConfig().getString("autoLoginFloodgate").toLowerCase(Locale.ROOT);
-        autoRegisterFloodgate = core.getConfig().getString("autoRegisterFloodgate").toLowerCase(Locale.ROOT);
-        allowNameConflict = core.getConfig().getString("allowFloodgateNameConflict").toLowerCase(Locale.ROOT);
+        autoLoginFloodgate = core.getConfig().get("autoLoginFloodgate").toString().toLowerCase(Locale.ROOT);
+        autoRegisterFloodgate = core.getConfig().get("autoRegisterFloodgate").toString().toLowerCase(Locale.ROOT);
+        allowNameConflict = core.getConfig().get("allowFloodgateNameConflict").toString().toLowerCase(Locale.ROOT);
     }
 
     @Override


### PR DESCRIPTION
[//]: # (Lines in this format are considered as comments and will not be displayed.)

[//]: # (If your work is in progress, please consider making a draft pull request.)

### Summary of your change

Fixes the way FloodgateManager reads the config, reverts it back to https://github.com/games647/FastLogin/tree/492a17e7de1eaf1dc2a9f539fc4ca6752388170a/

[//]: # (Example: motivation, enhancement)

### Related issue

#1173
