### PR TITLE
Floodgate Velocity fixes

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/ConnectionListener.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/ConnectionListener.java
@@ -90,6 +90,7 @@ public class ConnectionListener implements Listener {
                 if (floodgatePlayer != null) {
                     Runnable floodgateAuthTask = new FloodgateAuthTask(plugin.getCore(), player, floodgatePlayer);
                     Bukkit.getScheduler().runTaskAsynchronously(plugin, floodgateAuthTask);
+                    plugin.getBungeeManager().markJoinEventFired(player);
                     return;
                 }
             }

--- a/velocity/src/main/java/com/github/games647/fastlogin/velocity/FastLoginVelocity.java
+++ b/velocity/src/main/java/com/github/games647/fastlogin/velocity/FastLoginVelocity.java
@@ -230,4 +230,8 @@ public class FastLoginVelocity implements PlatformPlugin<CommandSource> {
     public UUID getProxyId() {
         return proxyId;
     }
+
+    public ProxyServer getServer() {
+        return server;
+    }
 }


### PR DESCRIPTION
### Summary of your change

First of all, I'm sorry for this awful reflection heavy code. I didn't want to add too many dependencies, so there are some type safety related warnings.

Two commits in this PR, but the second one is a one liner, and I'm lazy.

9a40cf0afb1d59d77892b098ca8fdbc13d33b4b9: After running the LOGIN event, it didn't get marked as run due to an early return. In Velocity, this caused all proxy commands to have no effect.

2d177e3df563fe30b4f8ab4ec42c07a8761fda07: Most of the Floodgate checks are run at the PreLoginEvent, which requires precise usernames. However, Floodgate only sets the correct username in GameProfileRequestEvent ([see here](https://github.com/GeyserMC/Floodgate/blob/49bd56446fa10931b1c4abf6609055571a4ae105/velocity/src/main/java/org/geysermc/floodgate/listener/VelocityListener.java#L185)). If username prefixes are used, this made FastLogin unable to detect Floodgate players at this stage of the login process.

### Related issue

Should fix pretty much every Floodgate & Velocity related issue.
Fixes https://github.com/games647/FastLogin/issues/1222
Fixes https://github.com/games647/FastLogin/issues/1176
Fixes https://github.com/games647/FastLogin/issues/1070
Fixes https://github.com/games647/FastLogin/issues/991
Fixes https://github.com/games647/FastLogin/issues/935
Fixes https://github.com/games647/FastLogin/issues/729