### PR TITLE
Revert ProtocoLlib Floodgate hack

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ProtocolLibListener.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ProtocolLibListener.java
@@ -231,6 +231,17 @@ public class ProtocolLibListener extends PacketAdapter {
         plugin.removeSession(player.getAddress());
 
         PacketContainer packet = packetEvent.getPacket();
+
+        //floodgate event listeners may run after our event listener
+        if (plugin.getFloodgateService() != null) {
+            FloodgatePlayer floodgatePlayer = getFloodgatePlayer(packetEvent.getPlayer());
+            if (floodgatePlayer != null) {
+                //add the floodgate prefix for our internal checks
+                //the correct username will be written to the packet by Floodgate
+                username = floodgatePlayer.getCorrectUsername();
+            }
+        }
+
         Optional<ClientPublicKey> clientKey;
         if (new MinecraftVersion(1, 19, 3).atOrAbove()) {
             // public key is sent separate


### PR DESCRIPTION
### Summary of your change

Removed the reimplemented Floodgate code from FastLogin. The bug blocking Floodgate from executing its checks has been fixed in https://github.com/dmulloy2/ProtocolLib/commit/f357ac85d0d66d554d8e876fdc6a48ee85a7665f (will be included in ProtocolLib v5.4.1).

Unfortunately, our checks still run before Floodgate's, so I had to manually add the Floodgate prefix to usernames for **our internal checks only**. The corrected username is now successfully written to the packet by Floodgate, so we don't have to do that.

### Related issue

https://github.com/GeyserMC/Floodgate/issues/143

### Other

https://github.com/games647/FastLogin/blob/be2ec1e5a8f0a4a2aace033b2ae82b4c868108fb/core/src/main/java/com/github/games647/fastlogin/core/shared/JoinManagement.java#L52

FastLogin still relies on usernames to determine if a connection is coming from Bedrock or not. Whilst this was reasonable a few years ago, when our code didn't have reflections to extract the Channel instance of a packet, it would be way safer if we passed actual FloodgatePlayer instances to JoinManagement.onLogin(). However, that refactor would require lots of testing (offline Java, floodgate linked, floodgate not linked, geyser offline, geyser premium) on all platforms (bukkit, bungee, velocity). I don't think I'll have time to do such refactoring in the near future. So it's easier to just hack the Floodgate prefix into our checks internally as a *temporary* solution. Getting rid of our reimplemented Floodgate code has obvious benefits: if Floodgate changes their code, we won't have to update our reimplementation.