### PR TITLE
Fix incompatibility by skipping offine encrypt instead of kick

### DIFF
--- a/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ProtocolLibListener.java
+++ b/bukkit/src/main/java/com/github/games647/fastlogin/bukkit/listener/protocollib/ProtocolLibListener.java
@@ -178,7 +178,7 @@ public class ProtocolLibListener extends PacketAdapter {
         if (session == null) {
             plugin.getLog().warn("Profile {} tried to send encryption response at invalid state", sender.getAddress());
             sender.kickPlayer(plugin.getCore().getMessage("invalid-request"));
-        } else {
+        } else if (session.getVerifyToken().length != 0) { // Skip offline player
             byte[] expectedVerifyToken = session.getVerifyToken();
             if (verifyNonce(sender, packetEvent.getPacket(), session.getClientPublicKey(), expectedVerifyToken)) {
                 packetEvent.getAsyncMarker().incrementProcessingDelay();


### PR DESCRIPTION
[//]: # (Lines in this format are considered as comments and will not be displayed.)

[//]: # (If your work is in progress, please consider making a draft pull request.)

### Summary of your change
Do not kick player when processing encryption on offline players, so the later netty handler can work correctly.

[//]: # (Example: motivation, enhancement)

### Motivation
I'm currently maintaining [a plugin that enable encryption on offline players](https://github.com/Lumine1909/OfflineEncryptor), and it is incompatible with FastLogin on both online and offline players. I added a fix  in my plugin that resolved online player encrypted twice. But currently FastLogin kick the offline player due to exception when processing encryption related packet, since their `verifyToken` is a empty array.

I added a check for offline player when doing encryption, so that my plugin can process the encrypt response packet later : )


### Related pr
https://github.com/Lumine1909/OfflineEncryptor/pull/6

[//]: # (Reference it using '#NUMBER'. Ex: Fixes/Related #...)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved login handling for offline players by skipping unnecessary encryption-token verification.
  - Preserved existing behavior for invalid login sessions, including session rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->